### PR TITLE
app: introduce initial Streamlit run visualization (WIP)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ crv-abm-sim = "crv.world.sim:main"
 crv-abm-sweep = "crv.world.sweep:main"
 crv-viz-report = "crv.viz.dashboards:cli_report"
 crv-lab = "crv.lab.cli:main"
-crv-viz-app = "crv.viz.app.app:main"
+crv-app = "app.main:main"
 
 [project.optional-dependencies]
 docs = [
@@ -81,6 +81,7 @@ no_implicit_optional = true
 [tool.hatch.build.targets.wheel]
 packages = [
   "src/crv",
+  "src/app",
 ]
 include = [
   "src/crv/core/core.ebnf",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+# Project-wide warning filters to ensure zero noisy third-party warnings during tests.
+# We still treat our own deprecations seriously (no blanket ignores).
+filterwarnings =
+    ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning:jupyter_client
+    ignore:.*SwigPyPacked has no __module__ attribute:DeprecationWarning
+    ignore:.*SwigPyObject has no __module__ attribute:DeprecationWarning
+    ignore:.*swigvarlink has no __module__ attribute:DeprecationWarning
+    ignore:.*declarative_base\(\) function is now available as sqlalchemy\.orm\.declarative_base:Warning

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+"""
+Top-level Streamlit app package.
+
+This package hosts the interactive CRV visualization app (Streamlit) decoupled
+from the crv.* library modules. Shared visualization utilities remain under
+crv.viz.*; the Streamlit UI shell and app-specific helpers live here.
+
+CLI entrypoint (configured in pyproject.toml):
+    crv-app = app.app:main
+"""

--- a/src/app/charts.py
+++ b/src/app/charts.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import altair as alt
+import polars as pl
+
+from crv.viz import events as _events
+from crv.viz import identity as _identity
+from crv.viz.base import normalize_time_object, to_values, validate_schema
+from crv.viz.networks import compute_circular_layout, plot_network
+from crv.viz.timeseries import (
+    plot_cee_small_multiples,
+    plot_counts_by_t,
+    plot_endowment,
+    plot_holdings_rate,
+    plot_valuation,
+)
+
+
+# Uniform chart defaults for a professional look
+def _apply_chart_defaults(ch: alt.TopLevelMixin) -> alt.TopLevelMixin:
+    try:
+        return (
+            ch.configure_axis(labelFontSize=12, titleFontSize=12, grid=True)
+            .configure_legend(labelFontSize=12, titleFontSize=12)
+            .configure_title(fontSize=14)
+            .configure_view(strokeOpacity=0)
+        )
+    except Exception:
+        # If configuration fails (e.g., non-top-level), return chart as-is
+        return ch
+
+
+# ----------------------------
+# Layering helpers (no inline casting in UI)
+# ----------------------------
+
+
+def layer_with_rule_y(base: object, y: float, *, color: str = "#999") -> alt.LayerChart:
+    """Return a LayerChart that overlays a horizontal rule at y on the base chart.
+
+    Args:
+        base (alt.TopLevelMixin): Base chart to layer on.
+        y (float): Y value for the rule.
+        color (str): Rule color (default '#999').
+
+    Returns:
+        alt.LayerChart: Layered chart.
+    """
+    rule = alt.Chart(alt.Data(values=[{"y": float(y)}])).mark_rule(color=color).encode(y="y:Q")
+    return alt.layer(base, rule)  # type: ignore
+
+
+def layer_with_overlay(base: object, overlay: object) -> alt.LayerChart:
+    """Return a LayerChart combining a base chart with an overlay chart.
+
+    Args:
+        base (alt.TopLevelMixin): Base chart.
+        overlay (alt.TopLevelMixin): Overlay chart (e.g., event rules).
+
+    Returns:
+        alt.LayerChart: Layered chart.
+    """
+    return alt.layer(base, overlay)  # type: ignore
+
+
+# ----------------------------
+# Overview
+# ----------------------------
+
+
+def overview_counts_by_t(at_df: pl.DataFrame) -> alt.TopLevelMixin:
+    """Mini bar chart of counts by t (delegates to timeseries.plot_counts_by_t)."""
+    ch = plot_counts_by_t(at_df)
+    return _apply_chart_defaults(ch.properties(title="Counts by time (t)"))
+
+
+# ----------------------------
+# Time series (server-side slice then reuse existing builders)
+# ----------------------------
+
+
+def _apply_ts_sampling(
+    df: pl.DataFrame, *, max_points: int | None, stride: int | None
+) -> pl.DataFrame:
+    if stride is not None and stride > 1:
+        return (
+            df.sort("t").with_row_index(name="_rn").filter(pl.col("_rn") % stride == 0).drop("_rn")
+        )
+    if max_points is not None and max_points > 0 and df.height > max_points:
+        # Approx even sample by stride
+        stride = max((df.height + max_points - 1) // max_points, 1)
+        return (
+            df.sort("t").with_row_index(name="_rn").filter(pl.col("_rn") % stride == 0).drop("_rn")
+        )
+    return df
+
+
+def apply_ts_sampling(
+    df: pl.DataFrame, *, max_points: int | None = None, stride: int | None = None
+) -> pl.DataFrame:
+    """Public wrapper for internal sampling; stable name for external callers."""
+    return _apply_ts_sampling(df, max_points=max_points, stride=stride)
+
+
+def ts_endowment_chart(
+    at_df: pl.DataFrame,
+    *,
+    group_field: str | None,
+    by_object_if_no_group: bool = True,
+    ts_max_points: int | None = None,
+    ts_stride: int | None = None,
+) -> alt.TopLevelMixin:
+    """Band+line endowment. Sampling applied to raw rows before aggregation."""
+    need = {"t", "s_io"}
+    if group_field:
+        need.add(group_field)
+    if by_object_if_no_group:
+        need.add("o")
+    df = at_df.select([c for c in at_df.columns if c in need]).clone()
+    df = _apply_ts_sampling(df, max_points=ts_max_points, stride=ts_stride)
+    return _apply_chart_defaults(
+        plot_endowment(df, group=group_field, by_object=by_object_if_no_group)
+    )
+
+
+def ts_valuation_chart(
+    at_df: pl.DataFrame,
+    *,
+    cost: float | None,
+    group_field: str | None,
+    ts_max_points: int | None = None,
+    ts_stride: int | None = None,
+) -> alt.TopLevelMixin:
+    need = {"t", "value_score"}
+    if group_field:
+        need.add(group_field)
+    df = at_df.select([c for c in at_df.columns if c in need]).clone()
+    df = _apply_ts_sampling(df, max_points=ts_max_points, stride=ts_stride)
+    return _apply_chart_defaults(plot_valuation(df, cost=cost, group=group_field))
+
+
+def ts_holdings_rate_chart(
+    at_df: pl.DataFrame,
+    *,
+    group_field: str | None,
+    ts_max_points: int | None = None,
+    ts_stride: int | None = None,
+) -> alt.TopLevelMixin:
+    need = {"t", "y_io"}
+    if group_field:
+        need.add(group_field)
+    df = at_df.select([c for c in at_df.columns if c in need]).clone()
+    df = _apply_ts_sampling(df, max_points=ts_max_points, stride=ts_stride)
+    return _apply_chart_defaults(plot_holdings_rate(df, group=group_field))
+
+
+# ----------------------------
+# Events timeline and overlays
+# ----------------------------
+
+
+def events_timeline_chart(
+    events_df: pl.DataFrame,
+    *,
+    types: list[str] | None = None,
+    filter_i: int | None = None,
+    filter_o: int | None = None,
+) -> alt.TopLevelMixin:
+    """Events timeline (delegates to crv.viz.events.timeline_chart)."""
+    return _apply_chart_defaults(
+        _events.timeline_chart(
+            events_df,
+            types=types,
+            filter_i=[filter_i] if filter_i is not None else None,
+            filter_o=[filter_o] if filter_o is not None else None,
+        )
+    )
+
+
+def overlay_event_rules(
+    events_df: pl.DataFrame, *, types: list[str] | None = None
+) -> alt.TopLevelMixin:
+    """Vertical rules overlay (delegates to crv.viz.events.overlay_rules)."""
+    return _apply_chart_defaults(_events.overlay_rules(events_df, types=types))
+
+
+# ----------------------------
+# Network snapshot at t_sel
+# ----------------------------
+
+
+def network_snapshot_chart(
+    rel_df: pl.DataFrame,
+    at_df: pl.DataFrame | None,
+    *,
+    t_sel: int,
+    edge_threshold: float | None = 0.05,
+    network_max_edges: int | None = None,
+) -> alt.TopLevelMixin:
+    """Build network snapshot using relations at a given time."""
+    rel_df = normalize_time_object(rel_df)
+    validate_schema(rel_df, {"t": pl.Int64, "i": pl.Int64, "j": pl.Int64})
+    if "a_ij" not in rel_df.columns:
+        raise ValueError("relations must include a_ij")
+
+    # Filter at t_sel
+    r = rel_df.filter(pl.col("t") == t_sel)
+    if r.height == 0:
+        # Empty placeholder
+        return _apply_chart_defaults(
+            alt.Chart(alt.Data(values=[]))
+            .mark_text()
+            .encode(text=alt.value(f"No edges at t={t_sel}"))
+        )
+
+    # Threshold or top-K by |a_ij|
+    r = r.with_columns([pl.col("a_ij").abs().alias("weight")])
+    if edge_threshold is not None:
+        r = r.filter(pl.col("weight") >= float(edge_threshold))
+    else:
+        # No threshold provided: drop zero-weight links so we don't draw a fully connected graph
+        r = r.filter(pl.col("weight") > 0)
+    if network_max_edges is not None and r.height > network_max_edges:
+        r = r.sort("weight", descending=True).head(network_max_edges)
+    # If after filtering there are no edges, return a placeholder rather than drawing zero-weight edges
+    if r.height == 0:
+        return _apply_chart_defaults(
+            alt.Chart(alt.Data(values=[]))
+            .mark_text()
+            .encode(text=alt.value(f"No edges at t={t_sel} (post-filter)"))
+        )
+
+    node_ids = sorted(set(r["i"].to_list()) | set(r["j"].to_list()))
+    layout = compute_circular_layout(node_ids)
+
+    # Optional group coloring from at_df at this t
+    nodes = layout
+    if at_df is not None and {"agent_id", "group", "t"}.issubset(set(at_df.columns)):
+        gmap = (
+            at_df.filter(pl.col("t") == t_sel)
+            .select(["agent_id", "group"])
+            .unique(keep="first")
+            .rename({"agent_id": "i"})
+        )
+        if gmap.height > 0:
+            nodes = nodes.join(gmap, on="i", how="left")
+    # Fallback: ensure a nominal 'group' column exists for coloring/validation
+    if "group" not in nodes.columns:
+        nodes = nodes.with_columns(pl.lit("all").alias("group"))
+
+    # Preserve src/dst before joins so optimizer doesn't drop them
+    r2 = r.with_columns([pl.col("i").alias("src"), pl.col("j").alias("dst")])
+
+    edges = (
+        r2.join(layout.rename({"i": "src", "x": "x1", "y": "y1"}), left_on="i", right_on="src")
+        .join(layout.rename({"i": "dst", "x": "x2", "y": "y2"}), left_on="j", right_on="dst")
+        .select(["src", "dst", "x1", "y1", "x2", "y2", "weight"])
+    )
+    return _apply_chart_defaults(
+        plot_network(nodes, edges, node_color="group", node_size=None, edge_weight="weight")
+    )
+
+
+# ----------------------------
+# Triads for agent_sel at t_sel
+# ----------------------------
+
+
+def triads_chart(
+    b_df: pl.DataFrame,
+    at_df: pl.DataFrame | None,
+    rel_df: pl.DataFrame | None,
+    *,
+    agent_sel: int,
+    t_sel: int,
+    triads_top_j: int = 3,
+    triads_top_o: int = 6,
+) -> alt.TopLevelMixin:
+    """Facet per-agent identity triads by peer j (rows) and object o (columns), plus mean bar (delegates to crv.viz.identity)."""
+    return _apply_chart_defaults(
+        _identity.plot_identity_triads(
+            b_df=b_df,
+            at_df=at_df,
+            rel_df=rel_df,
+            agent_sel=agent_sel,
+            t_sel=t_sel,
+            top_j=triads_top_j,
+            top_o=triads_top_o,
+        )
+    )
+
+
+# ----------------------------
+# CEE small multiples
+# ----------------------------
+
+
+def cee_small_multiples_chart(
+    cee_df: pl.DataFrame,
+    *,
+    cee_max_points: int | None = None,
+    cee_stride: int | None = None,
+    object_col: str = "o",
+    group_col: str = "group",
+) -> alt.TopLevelMixin:
+    """Stride/cap per object, then delegate to plot_cee_small_multiples."""
+    # Validate minimally (plot_cee_small_multiples will perform strict checks)
+    if not {"t", object_col, group_col, "cee"}.issubset(set(cee_df.columns)):
+        raise ValueError("cee_df missing required columns")
+
+    df = cee_df
+    # Apply stride per object to keep points bounded
+    if cee_stride is not None and cee_stride > 1:
+        parts: list[pl.DataFrame] = []
+        for _, g in df.group_by(object_col, maintain_order=True):
+            g2 = (
+                g.sort("t")
+                .with_row_index(name="_rn")
+                .filter(pl.col("_rn") % cee_stride == 0)
+                .drop("_rn")
+            )
+            parts.append(g2)
+        df = pl.concat(parts, how="vertical") if parts else df
+    elif cee_max_points is not None and cee_max_points > 0:
+        # Approx cap per object
+        out_parts: list[pl.DataFrame] = []
+        for o, g in df.group_by(object_col, maintain_order=True):
+            n = g.height
+            if n <= cee_max_points:
+                out_parts.append(g)
+            else:
+                stride = max((n + cee_max_points - 1) // cee_max_points, 1)
+                out_parts.append(
+                    g.sort("t")
+                    .with_row_index(name="_rn")
+                    .filter(pl.col("_rn") % stride == 0)
+                    .drop("_rn")
+                )
+        df = pl.concat(out_parts, how="vertical")
+
+    return _apply_chart_defaults(
+        plot_cee_small_multiples(df, object_col=object_col, group_col=group_col)
+    )
+
+
+# ----------------------------
+# Identity representation (per agent at time t)
+# ----------------------------
+
+
+def identity_representation_chart(
+    *,
+    at_df: pl.DataFrame,
+    rel_df: pl.DataFrame | None,
+    other_df: pl.DataFrame | None,
+    oo_df: pl.DataFrame | None = None,
+    agent_sel: int,
+    t_sel: int,
+    top_o: int = 6,
+    top_j: int = 6,
+    show_valence: bool = True,
+) -> alt.TopLevelMixin:
+    """Balanced identity representation (delegates to crv.viz.identity)."""
+    return _apply_chart_defaults(
+        _identity.plot_identity_representation(
+            at_df=at_df,
+            rel_df=rel_df,
+            other_df=other_df,
+            oo_df=oo_df,
+            agent_sel=agent_sel,
+            t_sel=t_sel,
+            top_o=top_o,
+            top_j=top_j,
+            show_valence=show_valence,
+        )
+    )
+
+
+def extract_identity_representation(
+    *,
+    at_df: pl.DataFrame,
+    rel_df: pl.DataFrame | None,
+    other_df: pl.DataFrame | None,
+    oo_df: pl.DataFrame | None,
+    agent_sel: int,
+    t_sel: int,
+    top_o: int = 6,
+    top_j: int = 6,
+) -> dict[str, list[dict[str, object]]]:
+    """Return the per-agent balanced-identity data at time t (no coordinates).
+
+    Returns a dictionary with:
+      - objects: [{o, s_io, rp, rn}]
+      - others: [{j, a_ij}]
+      - b_ijo: [{j, o, b_ijo}]
+    All slicing/aggregation done in Polars.
+    """
+    # Slice agent-token data
+    need_at = {"t", "o", "s_io", "agent_id"}
+    has_rp = "rp" in at_df.columns
+    has_rn = "rn" in at_df.columns
+    if has_rp:
+        need_at.add("rp")
+    if has_rn:
+        need_at.add("rn")
+    if not need_at.issubset(set(at_df.columns)):
+        return {"objects": [], "others": [], "b_ijo": []}
+
+    at_t = (
+        at_df.filter((pl.col("t") == t_sel) & (pl.col("agent_id") == agent_sel))
+        .select([c for c in at_df.columns if c in need_at])
+        .unique(keep="last")
+    )
+    objs = at_t.with_columns(pl.col("s_io").abs().alias("_abs")).sort("_abs", descending=True)
+    objs = objs.head(top_o).drop("_abs")
+    objs = objs.with_columns(
+        [
+            (pl.col("rp") if has_rp else pl.lit(0.0)).alias("rp"),
+            (pl.col("rn") if has_rn else pl.lit(0.0)).alias("rn"),
+        ]
+    ).select(["o", "s_io", "rp", "rn"])
+
+    # Slice self->other
+    if rel_df is not None and {"t", "i", "j", "a_ij"}.issubset(set(rel_df.columns)):
+        rdf = normalize_time_object(rel_df).filter(
+            (pl.col("t") == t_sel) & (pl.col("i") == agent_sel)
+        )
+        others = (
+            rdf.with_columns(pl.col("a_ij").abs().alias("_abs"))
+            .sort("_abs", descending=True)
+            .head(top_j)
+            .drop("_abs")
+            .select(["j", "a_ij"])
+        )
+    else:
+        others = pl.DataFrame(
+            {"j": pl.Series([], dtype=pl.Int64), "a_ij": pl.Series([], dtype=pl.Float64)}
+        )
+
+    # Slice other->object restricted to selected sets
+    if other_df is not None and {"t", "i", "j", "o", "b_ijo"}.issubset(set(other_df.columns)):
+        b = normalize_time_object(other_df).filter(
+            (pl.col("t") == t_sel) & (pl.col("i") == agent_sel)
+        )
+        sels_o = set(objs["o"].to_list())
+        sels_j = set(others["j"].to_list())
+        b = b.filter(pl.col("o").is_in(list(sels_o)) & pl.col("j").is_in(list(sels_j))).select(
+            ["j", "o", "b_ijo"]
+        )
+    else:
+        b = pl.DataFrame(
+            {
+                "j": pl.Series([], dtype=pl.Int64),
+                "o": pl.Series([], dtype=pl.Int64),
+                "b_ijo": pl.Series([], dtype=pl.Float64),
+            }
+        )
+
+    # Slice object<->object among selected objects
+    if oo_df is not None and {"t", "i", "o", "op", "r_oo"}.issubset(set(oo_df.columns)):
+        oo = normalize_time_object(oo_df).filter(
+            (pl.col("t") == t_sel) & (pl.col("i") == agent_sel)
+        )
+        sels_o = set(objs["o"].to_list())
+        oo = oo.filter(pl.col("o").is_in(list(sels_o)) & pl.col("op").is_in(list(sels_o))).select(
+            ["o", "op", "r_oo"]
+        )
+    else:
+        oo = pl.DataFrame(
+            {
+                "o": pl.Series([], dtype=pl.Int64),
+                "op": pl.Series([], dtype=pl.Int64),
+                "r_oo": pl.Series([], dtype=pl.Float64),
+            }
+        )
+
+    return {
+        "objects": to_values(objs),
+        "others": to_values(others),
+        "b_ijo": to_values(b),
+        "object_object": to_values(oo),
+    }

--- a/src/app/data.py
+++ b/src/app/data.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import streamlit as st
+
+from crv.viz.base import normalize_time_object, scan_parquet_columns
+
+__all__ = [
+    "CacheConfig",
+    "load_agents_tokens",
+    "load_relations",
+    "load_other_object",
+    "load_object_object",
+    "load_events",
+    "load_model_specs",
+    "get_time_bounds",
+    "even_sample",
+    "stride_sample",
+]
+
+# ---------- Cache configuration (factory of cached callables) ----------
+
+
+@dataclass(frozen=True)
+class CacheConfig:
+    """Hashable cache configuration for Streamlit @st.cache_data.
+
+    Note: Streamlit's decorator parameters (ttl, persist) are fixed at decoration
+    time. We build and memoize decorated callables per (name, ttl, persist) so the
+    app can switch these at runtime while still benefiting from caching.
+    """
+
+    ttl: int | None = None
+    persist: bool = False
+
+
+# Registry of decorated functions by (loader_name, CacheConfig)
+_CACHE_REGISTRY: dict[tuple[str, CacheConfig], Callable[..., Any]] = {}
+
+
+def _get_cached(loader_name: str, cfg: CacheConfig, fn: Callable[..., Any]) -> Callable[..., Any]:
+    key = (loader_name, cfg)
+    if key in _CACHE_REGISTRY:
+        return _CACHE_REGISTRY[key]
+    # Create a decorated wrapper with desired cache behavior
+    if cfg.persist:
+        wrapped = st.cache_data(persist="disk", ttl=cfg.ttl)(fn)
+    else:
+        wrapped = st.cache_data(ttl=cfg.ttl)(fn)
+    _CACHE_REGISTRY[key] = wrapped
+    return wrapped
+
+
+# ---------- Internal IO helpers (Polars-first, projection pushdown) ----------
+
+
+# ---------- Loaders (internal implementations) ----------
+
+
+def _load_agents_tokens_impl(run_dir: str) -> pl.DataFrame:
+    run = Path(run_dir)
+    path = run / "agents_tokens.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"Required file not found: {path}")
+    # Support Mesa v3+ alternates; normalize -> 't','o'
+    cols = [
+        "t",
+        "step",
+        "o",
+        "token_id",
+        "s_io",
+        "value_score",
+        "y_io",
+        "agent_id",
+        "group",
+        "s_pos",
+        "s_neg",
+        "rp",
+        "rn",
+    ]
+    df = scan_parquet_columns(str(path), cols)
+    df = normalize_time_object(df)
+    return df
+
+
+def _load_relations_impl(run_dir: str) -> pl.DataFrame | None:
+    run = Path(run_dir)
+    path = run / "relations.parquet"
+    if not path.exists():
+        return None
+    df = scan_parquet_columns(str(path), ["step", "i", "j", "a_ij"])
+    df = normalize_time_object(df)
+    # Ensure canonical columns present
+    need = {"t", "i", "j", "a_ij"}
+    if not need.issubset(set(df.columns)):
+        return None
+    return df
+
+
+def _load_other_object_impl(run_dir: str) -> pl.DataFrame | None:
+    run = Path(run_dir)
+    path = run / "other_object.parquet"
+    if not path.exists():
+        return None
+    df = scan_parquet_columns(str(path), ["step", "i", "j", "o", "b_ijo"])
+    df = normalize_time_object(df)
+    need = {"t", "i", "j", "o", "b_ijo"}
+    if not need.issubset(set(df.columns)):
+        return None
+    return df
+
+
+def _load_object_object_impl(run_dir: str) -> pl.DataFrame | None:
+    """Load object<->object structure (r_oo) if present; normalize step->t."""
+    run = Path(run_dir)
+    path = run / "object_object.parquet"
+    if not path.exists():
+        return None
+    df = scan_parquet_columns(str(path), ["step", "i", "o", "op", "r_oo"])
+    df = normalize_time_object(df)
+    need = {"t", "i", "o", "op", "r_oo"}
+    if not need.issubset(set(df.columns)):
+        return None
+    return df
+
+
+def _load_events_impl(run_dir: str) -> pl.DataFrame | None:
+    """Load events timeline if present; normalize step->t and pass through known fields.
+
+    Expected columns (subset): step|t, type, i, j, o, op, val, mode
+    """
+    run = Path(run_dir)
+    path = run / "events.parquet"
+    if not path.exists():
+        return None
+    desired = [
+        "step",
+        "t",
+        "time_created",
+        "type",
+        "i",
+        "j",
+        "o",
+        "op",
+        "p",
+        "val",
+        "mode",
+        "delivered",
+        "received",
+        "recipients",
+        "content",
+        "kind",
+        "status",
+        "actor",
+        "observer",
+        "origin",
+    ]
+    df = scan_parquet_columns(str(path), desired)
+    df = normalize_time_object(df)
+    # Require at least t and type to be present
+    need = {"t", "type"}
+    if not need.issubset(set(df.columns)):
+        return None
+    # Coerce type to string if necessary
+    casts: list[pl.Expr] = []
+    for column in ("type", "kind", "status", "origin"):
+        if column in df.columns and df.schema[column] != pl.Utf8:
+            casts.append(pl.col(column).cast(pl.Utf8))
+    if casts:
+        df = df.with_columns(casts)
+    return df
+
+
+def _load_model_specs_impl(run_dir: str) -> list[dict[str, str]]:
+    run = Path(run_dir)
+    model_path = run / "model.parquet"
+    meta_path = run / "metadata.json"
+    specs: dict[str, str] = {}
+
+    try:
+        if model_path.exists():
+            mdf = pl.read_parquet(model_path)
+            if mdf.height > 0:
+                row = mdf.row(0, named=True)
+                for key in ["seed", "n_agents", "n_tokens", "k", "steps"]:
+                    if key in row and row[key] is not None:
+                        specs[key] = str(row[key])
+        if meta_path.exists():
+            meta = pl.read_json(str(meta_path)).to_dicts()
+            if meta:
+                for key in ["agent_params", "model_params", "experiment_params"]:
+                    if key in meta[0]:
+                        val = str(meta[0][key])
+                        specs[key] = val[:180] + ("..." if len(val) > 180 else "")
+    except Exception:
+        # Best-effort; return what we have
+        pass
+
+    return [{"field": k, "value": v} for k, v in specs.items()]
+
+
+# ---------- Public loader APIs (dispatch to cached implementations) ----------
+
+
+def load_agents_tokens(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> pl.DataFrame:
+    fn = _get_cached("load_agents_tokens", cfg, _load_agents_tokens_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+def load_relations(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> pl.DataFrame | None:
+    fn = _get_cached("load_relations", cfg, _load_relations_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+def load_other_object(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> pl.DataFrame | None:
+    fn = _get_cached("load_other_object", cfg, _load_other_object_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+def load_object_object(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> pl.DataFrame | None:
+    """Return object_object (r_oo) long table or None if missing."""
+    fn = _get_cached("load_object_object", cfg, _load_object_object_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+def load_events(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> pl.DataFrame | None:
+    """Return events long table or None if missing."""
+    fn = _get_cached("load_events", cfg, _load_events_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+def load_model_specs(run_dir: str, *, cfg: CacheConfig = CacheConfig()) -> list[dict[str, str]]:
+    fn = _get_cached("load_model_specs", cfg, _load_model_specs_impl)
+    return fn(run_dir)  # type: ignore[no-any-return]
+
+
+# ---------- Time bounds ----------
+
+
+def get_time_bounds(df_at: pl.DataFrame) -> tuple[int, int]:
+    if "t" not in df_at.columns:
+        raise ValueError("get_time_bounds requires a 't' column")
+    if df_at.height == 0:
+        return (0, 0)
+    # Compute scalar min/max via aggregation and extract the first row
+    agg = df_at.select(pl.col("t").min().alias("t_min"), pl.col("t").max().alias("t_max"))
+    t_min_val, t_max_val = agg.row(0)
+    return (int(t_min_val), int(t_max_val))
+
+
+# ---------- Downsampling helpers (Polars-first) ----------
+
+
+def even_sample(df: pl.DataFrame, max_points: int) -> pl.DataFrame:
+    """Approx evenly-spaced sample by time globally to cap point count.
+
+    - Sort by t (if present), otherwise by row order
+    - Compute stride = ceil(n / max_points) and keep every stride-th row
+    - Deterministic for fixed input
+    """
+    if max_points <= 0:
+        raise ValueError("max_points must be positive")
+    n = df.height
+    if n <= max_points:
+        return df
+
+    if "t" in df.columns:
+        df2 = df.sort("t")
+    else:
+        df2 = df.clone()
+
+    stride = max((n + max_points - 1) // max_points, 1)
+    return df2.with_row_index(name="_rn").filter(pl.col("_rn") % stride == 0).drop("_rn")
+
+
+def stride_sample(df: pl.DataFrame, stride: int) -> pl.DataFrame:
+    """Keep every k-th row by time order (or original order if t missing)."""
+    if stride <= 1:
+        return df
+    if "t" in df.columns:
+        df2 = df.sort("t")
+    else:
+        df2 = df.clone()
+    return df2.with_row_index(name="_rn").filter(pl.col("_rn") % stride == 0).drop("_rn")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,0 +1,98 @@
+"""
+CRV App entrypoint.
+
+This module provides the CLI entrypoint to launch the Streamlit UI. It defers
+all UI composition to the app.ui package and exists solely to start Streamlit
+programmatically or render directly when already running under Streamlit.
+
+Usage:
+    - Python execution (hands process to Streamlit):
+        uv run python -m app.main --run out/demo_run --watch-ttl 10
+
+    - Streamlit direct:
+        streamlit run src/app/main.py -- --run out/demo_run --watch-ttl 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from app.ui import streamlit_app
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Console entrypoint that launches Streamlit with the CRV UI.
+
+    If already executing within a Streamlit server (environment variable
+    STREAMLIT_SERVER_PORT is set), this function renders the app directly.
+    Otherwise, it execs "python -m streamlit run <this_module>" to leverage
+    Streamlit's reloader and argument parsing, passing through any supported
+    options after "--".
+
+    Args:
+        argv (list[str] | None): Optional list of CLI arguments. If None,
+            sys.argv[1:] is used.
+
+    Examples:
+        uv run python -m app.main --run out/demo_run --watch-ttl 10
+        streamlit run src/app/main.py -- --run out/demo_run --watch-ttl 10
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    parser = argparse.ArgumentParser(description="CRV Streamlit App")
+    parser.add_argument("--run", default=None, help="Run directory (out/<run_dir>)")
+    parser.add_argument(
+        "--watch-ttl",
+        type=int,
+        default=10,
+        help="Auto-refresh interval (seconds) for run discovery (0 disables).",
+    )
+    ns = parser.parse_args(args)
+
+    # If invoked within Streamlit, just render
+    if os.environ.get("STREAMLIT_SERVER_PORT"):
+        streamlit_app(
+            default_run=ns.run,
+            default_roots=None,
+            default_watch_ttl=int(ns.watch_ttl),
+        )
+        return
+
+    # Otherwise, exec streamlit run on this module to take over the process
+    app_path = Path(__file__).resolve()
+    cmd = [sys.executable, "-m", "streamlit", "run", str(app_path)]
+
+    passthrough: list[str] = []
+    if ns.run:
+        passthrough += ["--run", ns.run]
+    if ns.watch_ttl is not None:
+        passthrough += ["--watch-ttl", str(int(ns.watch_ttl))]
+    if passthrough:
+        cmd += ["--"] + passthrough
+
+    try:
+        os.execv(sys.executable, cmd)
+    except Exception:
+        import subprocess
+
+        subprocess.run(cmd, check=False)
+
+
+if __name__ == "__main__":
+    # Support: --run, --watch-ttl after '--' when using `streamlit run`
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--run", default=None)
+    parser.add_argument("--watch-ttl", type=int, default=10)
+    try:
+        ns, _ = parser.parse_known_args(sys.argv[1:])
+        streamlit_app(
+            default_run=ns.run,
+            default_roots=None,
+            default_watch_ttl=int(ns.watch_ttl),
+        )
+    except SystemExit:
+        # Fallback to no-arg render
+        streamlit_app()

--- a/src/app/ui/__init__.py
+++ b/src/app/ui/__init__.py
@@ -1,0 +1,27 @@
+"""
+CRV App UI package.
+
+This package contains the decomposed Streamlit UI for the CRV dashboard. It exposes
+high-level orchestration and focused modules for separate concerns (header, runs,
+helpers), replacing the previous monolithic src/app/ui.py.
+
+Modules:
+    - app: Streamlit application orchestrator (streamlit_app).
+    - header: Global header (run picker, theme, cache preferences).
+    - runs: Run discovery, caching, and demo-run creation.
+    - helpers: Small cross-cutting helpers (accelerators, time formatting, KPIs).
+
+Usage:
+    from app.ui import streamlit_app
+    streamlit_app(default_run="out/demo_run", default_watch_ttl=10)
+"""
+
+from __future__ import annotations
+
+from .app import streamlit_app
+from .header import render_header
+
+__all__ = [
+    "streamlit_app",
+    "render_header",
+]

--- a/src/app/ui/app.py
+++ b/src/app/ui/app.py
@@ -1,0 +1,675 @@
+"""
+Streamlit application orchestrator for CRV.
+
+This module composes the global header and all page tabs while delegating
+supporting concerns to focused modules under app.ui.* (header, runs, helpers).
+It replaces the previous monolithic src/app/ui.py with a maintainable structure.
+
+Responsibilities:
+    - Configure Streamlit page.
+    - Render global header (run selector, theme, cache prefs).
+    - Load core run tables via app.data with configurable caching.
+    - Compute derived globals (time bounds, id lists).
+    - Mount tab content (Overview, Time Series, Network, Identity, Triads, CEE, Events, Data).
+
+Notes:
+    - Charts are produced by app.charts and crv.viz.* modules.
+    - All functions include Google-style docstrings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import altair as alt
+import polars as pl
+import streamlit as st
+
+from app import charts as app_charts
+from app.data import (
+    get_time_bounds,
+    load_agents_tokens,
+    load_events,
+    load_model_specs,
+    load_object_object,
+    load_other_object,
+    load_relations,
+)
+from crv.viz.timeseries import (
+    TimeseriesResult,
+    list_available_metrics,
+    prepare_metric_timeseries,
+    render_timeseries,
+)
+
+from .header import render_header
+from .helpers import compute_overview_kpis
+
+
+def streamlit_app(
+    default_run: str | None = None,
+    default_roots: list[str] | None = None,
+    default_watch_ttl: int = 10,
+) -> None:
+    """Render the CRV Streamlit application.
+
+    Args:
+        default_run (str | None): Optional preselected run directory path.
+        default_roots (list[str] | None): Retained for compatibility; roots are managed
+            in header preferences (ignored here).
+        default_watch_ttl (int): Default auto-refresh interval for run discovery.
+
+    Returns:
+        None
+
+    Notes:
+        - Uses app.ui.header.render_header to render the global controls and compute a
+          CacheConfig used by all loaders in app.data.
+        - When no runs are found, a minimal demo run is created under out/demo_run.
+    """
+    del default_roots  # managed via header preferences
+
+    # Page config
+    st.set_page_config(page_title="CRV App", layout="wide")
+
+    # Header (run selection, theme, cache preferences)
+    run_dir, cache_cfg = render_header(
+        default_run=default_run,
+        default_watch_ttl=default_watch_ttl,
+    )
+    if not run_dir:
+        st.error("Select a run directory (contains agents_tokens.parquet) from the header.")
+        return
+    run_path = Path(run_dir)
+
+    # Load core table (agents_tokens)
+    try:
+        with st.spinner("Loading agents_tokens ..."):
+            at_df = load_agents_tokens(str(run_path), cfg=cache_cfg)
+    except FileNotFoundError as e:
+        st.error(str(e))
+        return
+    except Exception as e:  # pragma: no cover - defensive UX
+        st.error(f"Failed to load agents_tokens: {e}")
+        return
+
+    # Derived globals & identifiers
+    try:
+        t_min, t_max = get_time_bounds(at_df)
+    except Exception:
+        t_min, t_max = (0, 0)
+    group_field = "group" if "group" in at_df.columns else None
+
+    agent_ids_all = (
+        sorted(set(at_df.get_column("agent_id").to_list())) if "agent_id" in at_df.columns else []
+    )
+    object_ids_all = sorted(set(at_df.get_column("o").to_list())) if "o" in at_df.columns else []
+    group_values_all = (
+        sorted(set(at_df.get_column("group").drop_nulls().to_list())) if group_field else []
+    )
+
+    # Tabs (page navigation)
+    tab_overview, tab_ts, tab_net, tab_id, tab_tri, tab_cee, tab_events, tab_data = st.tabs(
+        ["Overview", "Time Series", "Network", "Identity", "Triads", "CEE", "Events", "Data"]
+    )
+
+    # ----------------------------
+    # Overview
+    # ----------------------------
+    with tab_overview:
+        st.subheader("Run summary")
+        try:
+            specs = load_model_specs(str(run_path), cfg=cache_cfg)
+            if specs:
+                st.table(specs)
+            else:
+                st.caption("No model.parquet/metadata.json found.")
+        except Exception:
+            st.caption("Failed to load run specs.")
+
+        # KPIs
+        kpi = compute_overview_kpis(at_df)
+        c1, c2 = st.columns(2)
+        with c1:
+            st.metric("Final mean value_score", f"{kpi['final_mean_value']:.3f}")
+        with c2:
+            st.metric("Final holdings rate", f"{100.0 * kpi['final_hold_rate']:.1f}%")
+
+        st.subheader("Row count by time")
+        try:
+            ch = app_charts.overview_counts_by_t(at_df)
+            st.altair_chart(cast(Any, ch), theme=None, use_container_width=True)
+        except Exception as e:
+            st.error(f"Failed to render counts chart: {e}")
+
+    # ----------------------------
+    # Time Series
+    # ----------------------------
+    with tab_ts:
+        metric_specs = list_available_metrics()
+        metric_id_to_label = {spec["id"]: spec["label"] for spec in metric_specs}
+        metric_options = [spec["id"] for spec in metric_specs]
+        default_metrics = [
+            m for m in ("value_score", "s_io", "y_io") if m in metric_options
+        ] or metric_options[:1]
+
+        with st.sidebar.expander("Time Series Controls", expanded=True):
+            selected_metrics = st.multiselect(
+                "Metrics",
+                options=metric_options,
+                default=default_metrics,
+                format_func=lambda metric_id: str(metric_id_to_label.get(metric_id, metric_id)),
+                key="ts_metrics_select",
+            )
+            scope_choice = st.radio(
+                "Scope",
+                options=["Aggregate", "Group", "Agent"],
+                index=0,
+                key="ts_scope_choice",
+            )
+            scope_map = {"Aggregate": "aggregate", "Group": "group", "Agent": "agent"}
+            scope = scope_map[scope_choice]
+            if scope == "group" and not group_field:
+                st.warning("Run data has no group column; falling back to aggregate scope.")
+                scope = "aggregate"
+            scope_literal = cast(Literal["aggregate", "group", "agent"], scope)
+
+            show_quantiles = st.checkbox("Show quantile band", value=True, key="ts_show_quantiles")
+            quantile_band = st.slider(
+                "Quantile band (low/high)",
+                min_value=0.0,
+                max_value=1.0,
+                value=(0.1, 0.9),
+                step=0.05,
+                key="ts_quantile_band",
+            )
+            split_by_object_default = scope != "group"
+            split_by_object = st.checkbox(
+                "Split lines by object",
+                value=split_by_object_default,
+                key="ts_split_objects",
+            )
+            ts_max_points = st.number_input(
+                "Max points (0 disables)",
+                min_value=0,
+                value=500,
+                step=100,
+                key="ts_max_points",
+            )
+            ts_stride = st.number_input(
+                "Stride (every k; 0 disables)",
+                min_value=0,
+                value=0,
+                step=1,
+                key="ts_stride",
+            )
+            cost_line = None
+            if "value_score" in selected_metrics:
+                cost_line = st.number_input(
+                    "Reference line",
+                    min_value=-10.0,
+                    max_value=10.0,
+                    value=0.0,
+                    step=0.05,
+                    key="ts_cost_line",
+                )
+
+        with st.sidebar.expander("Filters", expanded=False):
+            agent_filter: list[int] | None = None
+            if scope == "agent" and agent_ids_all:
+                agent_selection = st.multiselect(
+                    "Agents",
+                    options=agent_ids_all,
+                    default=agent_ids_all[:1],
+                    key="ts_agent_filter",
+                )
+                agent_filter = agent_selection or None
+
+            group_filter: list[str] | None = None
+            if scope in ("group", "aggregate") and group_values_all:
+                default_groups = group_values_all if scope == "group" else []
+                group_selection = st.multiselect(
+                    "Groups",
+                    options=group_values_all,
+                    default=default_groups,
+                    key="ts_group_filter",
+                )
+                group_filter = group_selection or None
+
+            object_filter: list[int] | None = None
+            if object_ids_all:
+                object_selection = st.multiselect(
+                    "Objects", options=object_ids_all, default=[], key="ts_object_filter"
+                )
+                object_filter = object_selection or None
+
+        with st.sidebar.expander("Event Overlays", expanded=False):
+            overlay_enabled = st.checkbox(
+                "Show event markers", value=False, key="ts_overlay_enabled"
+            )
+            events_df = None
+            overlay_types: list[str] = []
+            if overlay_enabled:
+                try:
+                    events_df = load_events(str(run_path), cfg=cache_cfg)
+                except Exception:
+                    events_df = None
+                if events_df is None or events_df.is_empty():
+                    st.caption("No events available for overlay.")
+                    overlay_enabled = False
+                else:
+                    type_opts = (
+                        sorted(set(events_df.get_column("type").to_list()))
+                        if "type" in events_df.columns
+                        else []
+                    )
+                    overlay_types = st.multiselect(
+                        "Event types",
+                        options=type_opts,
+                        default=type_opts,
+                        key="ts_overlay_types",
+                    )
+
+        # Brush and charts
+        try:
+            counts = at_df.group_by("t").agg(pl.len().alias("n")).sort("t")
+        except Exception:
+            counts = pl.DataFrame({"t": [], "n": []})
+        top_vals = counts.to_dicts()
+        brush = alt.selection_interval(name="brush_t", encodings=["x"])
+        top = (
+            alt.Chart(alt.Data(values=top_vals))
+            .mark_bar()
+            .encode(x="t:Q", y="n:Q")
+            .add_params(brush)
+            .properties(title="Time window (brush to filter below)")
+        )
+
+        metric_charts: list[alt.Chart | alt.LayerChart] = []
+        quantiles_arg = cast(tuple[float, float] | None, st.session_state.get("ts_quantile_band"))
+        if not st.session_state.get("ts_show_quantiles", True):
+            quantiles_arg = None
+        max_points = int(st.session_state.get("ts_max_points", 500)) or None
+        stride = int(st.session_state.get("ts_stride", 0)) or None
+
+        for metric_id in selected_metrics:
+            result = prepare_metric_timeseries(
+                at_df,
+                metric_id,
+                scope=scope_literal,
+                agent_ids=agent_filter,
+                object_ids=object_filter,
+                groups=group_filter,
+                quantiles=quantiles_arg,
+                split_by_object=split_by_object,
+            )
+
+            frame = app_charts.apply_ts_sampling(
+                result.frame,
+                max_points=max_points,
+                stride=stride,
+            )
+            sampled_result = TimeseriesResult(
+                frame=frame,
+                value_field=result.value_field,
+                color_field=result.color_field,
+                quantile_fields=result.quantile_fields,
+                tooltip_fields=result.tooltip_fields,
+            )
+
+            chart = render_timeseries(sampled_result)
+
+            if metric_id == "value_score":
+                cost_line_val = st.session_state.get("ts_cost_line", None)
+                if cost_line_val is not None:
+                    chart = app_charts.layer_with_rule_y(chart, float(cost_line_val))
+
+            overlay_chart = None
+            if overlay_enabled and events_df is not None and not events_df.is_empty():
+                ev = events_df
+                if agent_filter:
+                    ev = ev.filter(pl.col("i").is_in(agent_filter))
+                if object_filter:
+                    ev = ev.filter(pl.col("o").is_in(object_filter))
+                if not ev.is_empty():
+                    overlay_chart = app_charts.overlay_event_rules(ev, types=overlay_types or None)
+
+            chart = chart.transform_filter(brush)
+            if overlay_chart is not None:
+                chart = app_charts.layer_with_overlay(chart, overlay_chart.transform_filter(brush))
+
+            metric_charts.append(
+                chart.properties(title=metric_id_to_label.get(metric_id, metric_id))
+            )
+
+        if not metric_charts:
+            st.info("Select at least one metric to display.")
+            ts_block = top
+        else:
+            ts_block = alt.vconcat(top, *metric_charts)
+        st.altair_chart(cast(Any, ts_block), theme=None, use_container_width=True)
+
+    # ----------------------------
+    # Network
+    # ----------------------------
+    with tab_net:
+        with st.sidebar.expander("Network Controls", expanded=True):
+            t_sel = st.slider(
+                "Time t", min_value=t_min, max_value=t_max, value=t_min, step=1, key="net_t_sel"
+            )
+            edge_mode = st.radio(
+                "Filter edges by", options=["Threshold", "Top-K"], index=0, key="net_edge_mode"
+            )
+            net_edge_thresh = st.number_input(
+                "Edge threshold |a_ij| \u2265",
+                min_value=0.0,
+                value=0.05,
+                step=0.01,
+                format="%.2f",
+                key="net_edge_thresh",
+            )
+            net_max_edges = st.number_input(
+                "Max edges (0 means unlimited)",
+                min_value=0,
+                value=200,
+                step=50,
+                key="net_max_edges",
+            )
+
+        st.subheader(f"Agent network at t = {t_sel}")
+        rel_df = load_relations(str(run_path), cfg=cache_cfg)
+        if rel_df is None:
+            st.info("relations.parquet not found.")
+        else:
+            ch_net = app_charts.network_snapshot_chart(
+                rel_df,
+                at_df=at_df,
+                t_sel=int(t_sel),
+                edge_threshold=float(net_edge_thresh) if edge_mode == "Threshold" else None,
+                network_max_edges=int(net_max_edges)
+                if (edge_mode == "Top-K" and net_max_edges > 0)
+                else None,
+            )
+            st.altair_chart(cast(Any, ch_net), theme=None, use_container_width=True)
+
+    # ----------------------------
+    # Identity (per-agent balanced-identity representation)
+    # ----------------------------
+    with tab_id:
+        with st.sidebar.expander("Identity Controls", expanded=True):
+            agent_ids = (
+                sorted(set(at_df.get_column("agent_id").to_list()))
+                if "agent_id" in at_df.columns
+                else []
+            )
+            agent_sel: int | None = (
+                cast(int, st.selectbox("Agent", options=agent_ids, index=0, key="id_agent_sel"))
+                if agent_ids
+                else None
+            )
+            t_sel = st.slider(
+                "Time t", min_value=t_min, max_value=t_max, value=t_min, step=1, key="id_t_sel"
+            )
+            id_top_o = st.number_input(
+                "Top-O objects by |s_io|", min_value=1, value=6, step=1, key="id_top_o"
+            )
+            id_top_j = st.number_input(
+                "Top-J others by |a_ij|", min_value=1, value=6, step=1, key="id_top_j"
+            )
+            show_valence = st.checkbox(
+                "Show object→valence edges (rp/rn)", value=True, key="id_show_valence"
+            )
+
+        st.subheader("Balanced identity representation")
+        if agent_sel is None:
+            st.info("No agents in agents_tokens.")
+        else:
+            rel_df = load_relations(str(run_path), cfg=cache_cfg)
+            other_df = load_other_object(str(run_path), cfg=cache_cfg)
+            oo_df = load_object_object(str(run_path), cfg=cache_cfg)
+            ch_id = app_charts.identity_representation_chart(
+                at_df=at_df,
+                rel_df=rel_df,
+                other_df=other_df,
+                oo_df=oo_df,
+                agent_sel=int(agent_sel),
+                t_sel=int(t_sel),
+                top_o=int(id_top_o),
+                top_j=int(id_top_j),
+                show_valence=bool(show_valence),
+            )
+            st.altair_chart(cast(Any, ch_id), theme=None, use_container_width=True)
+
+    # ----------------------------
+    # Triads
+    # ----------------------------
+    with tab_tri:
+        other_df = load_other_object(str(run_path), cfg=cache_cfg)
+        with st.sidebar.expander("Triads Controls", expanded=True):
+            t_sel = st.slider(
+                "Time t", min_value=t_min, max_value=t_max, value=t_min, step=1, key="tri_t_sel"
+            )
+            agent_sel: int | None = None
+            if other_df is not None and "i" in other_df.columns:
+                agent_ids = sorted(set(other_df.get_column("i").to_list()))
+                if agent_ids:
+                    agent_sel = cast(
+                        int,
+                        st.selectbox(
+                            "Agent (for triads)", options=agent_ids, index=0, key="tri_agent_sel"
+                        ),
+                    )
+            triads_top_j = st.number_input(
+                "Triads: top-J peers", min_value=1, value=3, step=1, key="tri_top_j"
+            )
+            triads_top_o = st.number_input(
+                "Triads: top-O objects", min_value=1, value=6, step=1, key="tri_top_o"
+            )
+
+        st.subheader(f"Identity triads at t = {t_sel}")
+        if other_df is None:
+            st.info("other_object.parquet not found.")
+        elif agent_sel is None:
+            st.info("No agent available for triads.")
+        else:
+            rel_df = load_relations(str(run_path), cfg=cache_cfg)
+            ch_tri = app_charts.triads_chart(
+                other_df,
+                at_df=at_df,
+                rel_df=rel_df,
+                agent_sel=int(agent_sel),
+                t_sel=int(t_sel),
+                triads_top_j=int(triads_top_j),
+                triads_top_o=int(triads_top_o),
+            )
+            st.altair_chart(cast(Any, ch_tri), theme=None, use_container_width=True)
+
+    # ----------------------------
+    # CEE
+    # ----------------------------
+    with tab_cee:
+        with st.sidebar.expander("CEE Controls", expanded=True):
+            cee_max_points = st.number_input(
+                "CEE max points per object (0 disables cap)",
+                min_value=0,
+                value=500,
+                step=100,
+                key="cee_max_points",
+            )
+            cee_stride = st.number_input(
+                "CEE stride (every k; 0 disables)",
+                min_value=0,
+                value=0,
+                step=1,
+                key="cee_stride",
+            )
+            cee_independent_y = st.checkbox(
+                "Independent Y scales per object", value=False, key="cee_independent_y"
+            )
+            show_y0 = st.checkbox("Show y=0 reference line", value=True, key="cee_show_y0")
+
+        st.subheader("CEE small multiples")
+        cee_path = run_path / "cee.parquet"
+        if not cee_path.exists():
+            st.info("cee.parquet not found.")
+        else:
+            try:
+                # Minimal cached loader for CEE (Polars-first)
+                def _load_cee_impl(p: str) -> pl.DataFrame:
+                    lf = pl.scan_parquet(p)
+                    names = lf.collect_schema().names()
+                    want = [c for c in ["t", "o", "token_id", "group", "cee"] if c in names]
+                    df = lf.select(want).collect()
+                    # Normalize token_id->o if present
+                    if "o" not in df.columns and "token_id" in df.columns:
+                        df = df.rename({"token_id": "o"})
+                    return df
+
+                if cache_cfg.persist:
+                    _load_cee = st.cache_data(ttl=cache_cfg.ttl, persist="disk")(_load_cee_impl)
+                else:
+                    _load_cee = st.cache_data(ttl=cache_cfg.ttl)(_load_cee_impl)
+
+                cee_df = _load_cee(str(cee_path))
+                ch_cee = app_charts.cee_small_multiples_chart(
+                    cee_df,
+                    cee_max_points=int(cee_max_points) if cee_max_points > 0 else None,
+                    cee_stride=int(cee_stride) if cee_stride > 0 else None,
+                    object_col="o",
+                    group_col="group",
+                )
+                # Optional y=0 rule overlay
+                if show_y0:
+                    ch_cee = app_charts.layer_with_rule_y(ch_cee, 0.0)
+                # Optional independent y scales per object facet
+                if cee_independent_y:
+                    ch_cee = ch_cee.resolve_scale(y="independent")
+                st.altair_chart(cast(Any, ch_cee), theme=None, use_container_width=True)
+            except Exception as e:
+                st.error(f"Failed to load/render CEE: {e}")
+
+    # ----------------------------
+    # Events
+    # ----------------------------
+    with tab_events:
+        with st.sidebar.expander("Events Controls", expanded=True):
+            ev = load_events(str(run_path), cfg=cache_cfg)
+            if ev is None or ev.is_empty():
+                st.info("events.parquet not found.")
+            else:
+                # Options
+                if "type" in ev.columns:
+                    try:
+                        types_opts = sorted(set(ev.get_column("type").to_list()))
+                    except Exception:
+                        types_opts = []
+                else:
+                    types_opts = []
+                types_sel = st.multiselect(
+                    "Event types",
+                    options=types_opts,
+                    default=types_opts,
+                    key="events_types",
+                )
+                filter_i = None
+                filter_o = None
+                if "i" in ev.columns:
+                    try:
+                        i_opts = sorted(set(ev.get_column("i").to_list()))
+                    except Exception:
+                        i_opts = []
+                    if i_opts:
+                        filter_i = cast(
+                            Any,
+                            st.selectbox(
+                                "Filter agent i (optional)",
+                                options=[None] + i_opts,
+                                index=0,
+                                key="events_filter_i",
+                            ),
+                        )
+                if "o" in ev.columns:
+                    try:
+                        o_opts = sorted(set(ev.get_column("o").to_list()))
+                    except Exception:
+                        o_opts = []
+                    if o_opts:
+                        filter_o = cast(
+                            Any,
+                            st.selectbox(
+                                "Filter object o (optional)",
+                                options=[None] + o_opts,
+                                index=0,
+                                key="events_filter_o",
+                            ),
+                        )
+
+                st.subheader("Events timeline")
+                ch_ev = app_charts.events_timeline_chart(
+                    ev,
+                    types=types_sel or None,
+                    filter_i=cast(int, filter_i) if isinstance(filter_i, int) else None,
+                    filter_o=cast(int, filter_o) if isinstance(filter_o, int) else None,
+                )
+                st.altair_chart(cast(Any, ch_ev), theme=None, use_container_width=True)
+
+                st.subheader("Events preview")
+                try:
+                    st.dataframe(ev.head(200), width="stretch")
+                    st.text(f"Rows: {ev.height}, Columns: {list(ev.columns)}")
+                except Exception as e:
+                    st.error(f"Failed to render events: {e}")
+
+    # ----------------------------
+    # Data (table viewer)
+    # ----------------------------
+    with tab_data:
+        with st.sidebar.expander("Data Viewer Controls", expanded=True):
+            head_n = st.number_input(
+                "Show first N rows", min_value=5, value=100, step=25, key="data_head_n"
+            )
+
+        st.subheader("agents_tokens.parquet (normalized)")
+        st.caption(
+            "Columns shown may include: t, agent_id, o/token_id→o, s_io, rp, rn, y_io, value_score, s_pos, s_neg, salience, group"
+        )
+        try:
+            # Already loaded at_df is normalized (step→t, token_id→o) in loader
+            at_preview = at_df.head(int(head_n))
+            st.dataframe(at_preview, width="stretch")
+            st.text(f"Rows: {at_df.height}, Columns: {list(at_df.columns)}")
+        except Exception as e:
+            st.error(f"Failed to render agents_tokens: {e}")
+
+        st.subheader("relations.parquet (if present)")
+        try:
+            rel_df = load_relations(str(run_path), cfg=cache_cfg)
+            if rel_df is None or rel_df.is_empty():
+                st.caption("Relations not found.")
+            else:
+                st.dataframe(rel_df.head(int(head_n)), width="stretch")
+                st.text(f"Rows: {rel_df.height}, Columns: {list(rel_df.columns)}")
+        except Exception as e:
+            st.error(f"Failed to render relations: {e}")
+
+        st.subheader("other_object.parquet (if present)")
+        try:
+            other_df = load_other_object(str(run_path), cfg=cache_cfg)
+            if other_df is None or other_df.is_empty():
+                st.caption("Other→object (b_ijo) not found.")
+            else:
+                st.dataframe(other_df.head(int(head_n)), width="stretch")
+                st.text(f"Rows: {other_df.height}, Columns: {list(other_df.columns)}")
+        except Exception as e:
+            st.error(f"Failed to render other_object: {e}")
+
+        st.subheader("Run specs (model.parquet + metadata.json)")
+        try:
+            specs = load_model_specs(str(run_path), cfg=cache_cfg)
+            if specs:
+                st.table(specs)
+            else:
+                st.caption("No model.parquet/metadata.json found or parsable.")
+        except Exception as e:
+            st.error(f"Failed to render specs: {e}")

--- a/src/app/ui/header.py
+++ b/src/app/ui/header.py
@@ -1,0 +1,230 @@
+"""
+Header (global controls) for the CRV Streamlit application.
+
+This module renders the top-of-page controls, including:
+- Run selection and discovery preferences (watch roots, refresh interval).
+- Manual refresh button and optional demo-run creation on empty trees.
+- Theme selection and cache preferences panel.
+- Construction of a CacheConfig used by data loaders.
+
+Notes:
+    - Avoids performing heavy IO directly; uses ui.runs for scanning and caching.
+    - Applies the selected CRV viz theme globally via crv.viz.theme.enable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import streamlit as st
+
+from app.data import CacheConfig
+from crv.viz import theme as crv_theme
+
+from .helpers import enable_vegafusion_optional, format_ts, humanize_ago
+from .runs import cached_list_runs, create_min_demo_run, list_runs_impl
+
+
+def render_header(
+    *,
+    default_run: str | None,
+    default_watch_ttl: int,
+) -> tuple[str, CacheConfig]:
+    """Render the global header and return the selected run path and cache config.
+
+    The header provides:
+      - Run selector populated from discovered runs under configured roots.
+      - Preferences for watch roots and auto-refresh interval.
+      - Theme selector (crv_light/crv_dark).
+      - Cache controls: TTL and persist-to-disk toggle.
+
+    Args:
+        default_run (str | None): Optional preselected run path.
+        default_watch_ttl (int): Default auto-refresh interval for run discovery.
+
+    Returns:
+        tuple[str, CacheConfig]: (selected_run_path_or_empty, cache_config)
+
+    Notes:
+        - When no runs are found under the current roots, a minimal demo run is
+          created under 'out/demo_run' and a subsequent refresh is triggered.
+        - The cache configuration returned is used by app.data loaders to build
+          decorated callables with matching Streamlit caching semantics.
+    """
+    # Title and optional accelerator
+    st.markdown("### CRV App")
+    accel_msg = enable_vegafusion_optional()
+    if accel_msg:
+        st.caption(accel_msg)
+
+    # Session defaults
+    if "watch_roots" not in st.session_state:
+        st.session_state["watch_roots"] = ["out"]
+    if "watch_ttl" not in st.session_state:
+        st.session_state["watch_ttl"] = int(default_watch_ttl)
+    if "watch_refresh_bump" not in st.session_state:
+        st.session_state["watch_refresh_bump"] = 0
+    if "theme_choice" not in st.session_state:
+        st.session_state["theme_choice"] = "crv_light"
+    if "cache_ttl" not in st.session_state:
+        st.session_state["cache_ttl"] = 600
+    if "cache_persist" not in st.session_state:
+        st.session_state["cache_persist"] = False
+
+    # Resolve runs list (cached)
+    roots = tuple(sorted(set(map(str, st.session_state["watch_roots"] or ["out"]))))
+    runs = cached_list_runs(roots, 200)
+
+    # If nothing in 'out', try 'runs'
+    if not runs and ("runs" not in roots) and Path("runs").exists():
+        runs = list_runs_impl(["runs"], 200)
+
+    # If still none, create demo run
+    if not runs:
+        try:
+            demo_path = Path("out") / "demo_run"
+            create_min_demo_run(demo_path)
+            st.success(f"No runs found. Created demo run at {demo_path}")
+            st.session_state["watch_refresh_bump"] += 1
+            runs = cached_list_runs(tuple(["out"]), 200)
+        except Exception as e:  # pragma: no cover - defensive UX
+            st.error(f"Failed to create demo run automatically: {e}")
+
+    # Build header columns
+    c1, c2, c3 = st.columns([0.42, 0.38, 0.20])
+
+    # Left: Run selector and updated caption
+    option_to_path: dict[str, str] = {}
+    options: list[str] = []
+    for item in runs:
+        label = f"{item['name']} — updated {humanize_ago(item['mtime'])}"
+        option_to_path[label] = item["path"]
+        options.append(label)
+    selected_label_default_index = 0
+
+    # Preselect by default_run if provided, else prior session state if present
+    if default_run:
+        try:
+            dpath = str(Path(default_run).resolve())
+            for lab, pth in option_to_path.items():
+                if str(Path(pth).resolve()) == dpath:
+                    selected_label_default_index = options.index(lab)
+                    break
+        except Exception:
+            pass
+    elif (
+        "selected_run_label" in st.session_state
+        and st.session_state["selected_run_label"] in options
+    ):
+        selected_label_default_index = options.index(st.session_state["selected_run_label"])
+
+    with c1:
+        selected_label = st.selectbox(
+            "Run",
+            options=options or ["(no runs found)"],
+            index=selected_label_default_index if options else 0,
+            key="run_selector_header",
+        )
+        selected_run_path = option_to_path.get(selected_label, "") if options else ""
+        # Updated timestamp
+        if selected_run_path:
+            try:
+                mtime = Path(selected_run_path).stat().st_mtime
+            except Exception:
+                mtime = 0.0
+            st.caption(f"Updated: {format_ts(mtime)} ({humanize_ago(mtime)})")
+        else:
+            st.caption("Select a run directory containing agents_tokens.parquet.")
+
+    # Middle: Refresh + Preferences (watch roots)
+    with c2:
+        cols_mid = st.columns([0.33, 0.67])
+        with cols_mid[0]:
+            if st.button("Refresh"):
+                st.session_state["watch_refresh_bump"] += 1
+                st.rerun()
+        with cols_mid[1]:
+            with st.expander("Preferences", expanded=False):
+                # Watch roots (global)
+                roots_all = st.multiselect(
+                    "Watch roots",
+                    options=sorted(set(st.session_state["watch_roots"] + ["out", "runs"])),
+                    default=st.session_state["watch_roots"],
+                    help="Directories scanned recursively for runs.",
+                    key="pref_watch_roots",
+                )
+                add_root = st.text_input(
+                    "Add root (absolute or relative path)",
+                    value="",
+                    placeholder="e.g., runs/local or /abs/path/to/runs",
+                    key="pref_watch_add_root",
+                )
+                if add_root:
+                    p = Path(add_root)
+                    if p.exists():
+                        if str(p) not in roots_all:
+                            roots_all.append(str(p))
+                    else:
+                        st.caption("Path does not exist; not added.")
+                st.session_state["watch_roots"] = roots_all or ["out"]
+
+                # Auto-refresh interval (used for caching TTL)
+                watch_ttl = st.number_input(
+                    "Auto-refresh interval (seconds)",
+                    min_value=0,
+                    value=int(st.session_state["watch_ttl"]),
+                    step=5,
+                    key="pref_watch_ttl",
+                )
+                st.session_state["watch_ttl"] = int(watch_ttl)
+
+                st.caption(
+                    f"Watching {len(st.session_state['watch_roots'])} root(s), found {len(runs)} run(s)."
+                )
+
+    # Right: Theme + Cache Preferences (global)
+    with c3:
+        theme_choice = st.selectbox(
+            "Theme",
+            options=["crv_light", "crv_dark"],
+            index=0 if st.session_state["theme_choice"] == "crv_light" else 1,
+            key="theme_choice_header",
+        )
+        st.session_state["theme_choice"] = theme_choice
+
+        # Global cache settings (apply via CacheConfig)
+        with st.expander("Cache", expanded=False):
+            ttl = st.number_input(
+                "Cache TTL (seconds)",
+                min_value=0,
+                value=int(st.session_state["cache_ttl"]),
+                step=60,
+                help="0 disables TTL",
+                key="cache_ttl_header",
+            )
+            persist = st.checkbox(
+                "Persist to disk",
+                value=bool(st.session_state["cache_persist"]),
+                key="cache_persist_header",
+            )
+            st.session_state["cache_ttl"] = int(ttl)
+            st.session_state["cache_persist"] = bool(persist)
+
+    # Apply theme globally
+    theme_val: Literal["crv_light", "crv_dark"] = (
+        "crv_light" if st.session_state["theme_choice"] == "crv_light" else "crv_dark"
+    )
+    crv_theme.enable(theme_val)  # type: ignore[arg-type]
+
+    # Update selected run in state
+    st.session_state["selected_run_label"] = selected_label
+    st.session_state["selected_run_path"] = selected_run_path or (default_run or "")
+
+    # Build cache config for loaders
+    cache_cfg = CacheConfig(
+        ttl=int(st.session_state["cache_ttl"]) if int(st.session_state["cache_ttl"]) > 0 else None,
+        persist=bool(st.session_state["cache_persist"]),
+    )
+
+    return (st.session_state["selected_run_path"] or "", cache_cfg)

--- a/src/app/ui/helpers.py
+++ b/src/app/ui/helpers.py
@@ -1,0 +1,115 @@
+"""
+Shared UI helper utilities for the CRV Streamlit application.
+
+This module centralizes small cross-cutting helpers (accelerators, time formatting,
+quick KPI computations) used by multiple UI components. Keeping these here avoids
+circular imports and makes per-tab modules leaner.
+
+Notes:
+    - All functions include Google-style docstrings.
+    - This module is UI-adjacent (uses Altair and Streamlit-friendly utilities)
+      but contains no Streamlit state manipulation itself.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import altair as alt
+import polars as pl
+
+
+def enable_vegafusion_optional() -> str | None:
+    """Attempt to enable the VegaFusion accelerator for Altair if available.
+
+    Returns:
+        str | None: Short status message if enabling succeeded, otherwise None.
+
+    Notes:
+        This is an optional performance accelerator. If the environment does not
+        have VegaFusion installed or configured, the function will fail silently
+        and return None.
+    """
+    try:
+        alt.data_transformers.enable("vegafusion")
+        return "VegaFusion enabled (optional accelerator)."
+    except Exception:
+        return None
+
+
+def humanize_ago(ts: float) -> str:
+    """Convert a UNIX timestamp into a short humanized age string.
+
+    Args:
+        ts (float): UNIX timestamp (seconds since epoch).
+
+    Returns:
+        str: Humanized string like "32s ago", "5m ago", "2h ago", "3d ago",
+        or "n/a" if conversion fails.
+    """
+    try:
+        dt = datetime.fromtimestamp(ts, tz=UTC)
+        now = datetime.now(tz=UTC)
+        delta = (now - dt).total_seconds()
+        if delta < 60:
+            return f"{int(delta)}s ago"
+        if delta < 3600:
+            return f"{int(delta // 60)}m ago"
+        if delta < 86400:
+            return f"{int(delta // 3600)}h ago"
+        return f"{int(delta // 86400)}d ago"
+    except Exception:
+        return "n/a"
+
+
+def format_ts(ts: float) -> str:
+    """Format a UNIX timestamp as a local datetime string.
+
+    Args:
+        ts (float): UNIX timestamp (seconds since epoch).
+
+    Returns:
+        str: Formatted timestamp "YYYY-MM-DD HH:MM:SS", or "n/a" on failure.
+    """
+    try:
+        dt = datetime.fromtimestamp(ts)
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return "n/a"
+
+
+def compute_overview_kpis(at_df: pl.DataFrame) -> dict[str, float]:
+    """Compute quick KPI metrics from a normalized agents_tokens DataFrame.
+
+    Computes:
+        - final_mean_value: Mean of value_score at the final time t.
+        - final_hold_rate: Share of rows with y_io == 1 at the final time t.
+
+    Args:
+        at_df (pl.DataFrame): Normalized agents_tokens Polars DataFrame. Expected
+            to include column "t". If not present, zeros are returned.
+
+    Returns:
+        dict[str, float]: KPI dictionary with keys "final_mean_value" and "final_hold_rate".
+    """
+    if at_df.is_empty() or "t" not in at_df.columns:
+        return {"final_mean_value": 0.0, "final_hold_rate": 0.0}
+    # Use aggregation to avoid Optional typing issues with Series.max
+    tmax_df = at_df.select(pl.col("t").max().alias("_tmax"))
+    t_max = int(tmax_df.get_column("_tmax").item())
+    last = at_df.filter(pl.col("t") == t_max)
+    # Mean valuation (robust scalar extraction)
+    if "value_score" in last.columns:
+        mdf = last.select(pl.col("value_score").mean().alias("_m"))
+        mean_val = float(mdf.get_column("_m").item())
+    else:
+        mean_val = 0.0
+    # Holdings rate (share of y_io == 1)
+    if "y_io" in last.columns:
+        hr_df = last.with_columns(((pl.col("y_io") == 1).cast(pl.Float64)).alias("_held")).select(
+            pl.col("_held").mean().alias("_m")
+        )
+        hold_rate = float(hr_df.get_column("_m").item())
+    else:
+        hold_rate = 0.0
+    return {"final_mean_value": mean_val, "final_hold_rate": hold_rate}

--- a/src/app/ui/runs.py
+++ b/src/app/ui/runs.py
@@ -1,0 +1,171 @@
+"""
+Run discovery and demo-run utilities for the CRV Streamlit UI.
+
+This module encapsulates:
+- Run directory scanning under one or more roots.
+- Minimal demo run creation to bootstrap the UI when no runs exist.
+- A cached wrapper around run listing suitable for Streamlit usage.
+
+Notes:
+    - File-system operations are localized here.
+    - Streamlit caching is provided via `cached_list_runs`.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import streamlit as st
+
+# Public constants
+IGNORED_DIRS: set[str] = {".venv", "site", ".git", "node_modules", "__pycache__"}
+
+
+def list_recent_runs_under(base: Path) -> Iterable[Path]:
+    """Yield candidate self-contained run directories under a base folder.
+
+    A run is considered self-contained if it contains:
+      - agents_tokens.parquet, and at least one of:
+        * model.parquet
+        * metadata.json
+        * manifest_*.json
+
+    Args:
+        base (Path): Base directory to scan recursively.
+
+    Yields:
+        Path: Paths to run directories that satisfy the conditions.
+
+    Notes:
+        - Directory trees matching IGNORED_DIRS are skipped.
+        - This function is IO-bound and intended to be called from a cached wrapper.
+    """
+    if not base.exists() or not base.is_dir():
+        return []
+    for p in base.rglob("*"):
+        if not p.is_dir():
+            continue
+        if any(seg in IGNORED_DIRS for seg in p.parts):
+            continue
+        at = p / "agents_tokens.parquet"
+        if not at.exists():
+            continue
+        model_ok = (p / "model.parquet").exists() or (p / "metadata.json").exists()
+        manifest_ok = any(
+            child.name.startswith("manifest_") and child.suffix == ".json"
+            for child in p.glob("manifest_*.json")
+        )
+        if model_ok or manifest_ok:
+            yield p
+
+
+def list_runs_impl(roots: list[str], limit: int = 200) -> list[dict[str, Any]]:
+    """Return a list of recent runs with minimal metadata for header selector.
+
+    Args:
+        roots (list[str]): Root directories to scan (absolute or relative paths).
+        limit (int): Maximum number of run candidates to return (best-effort).
+
+    Returns:
+        list[dict[str, Any]]: Run metadata dicts with keys: "path", "name", "mtime".
+
+    Notes:
+        - Resolves duplicates by absolute path.
+        - Prefers leaf-most directories and sorts by recency (mtime).
+    """
+    seen: set[str] = set()
+    items: list[dict[str, Any]] = []
+    for root in roots:
+        base = Path(root)
+        for p in list_recent_runs_under(base):
+            sp = str(p.resolve())
+            if sp in seen:
+                continue
+            seen.add(sp)
+            try:
+                mtime = p.stat().st_mtime
+            except Exception:
+                mtime = 0.0
+            items.append({"path": sp, "name": p.name, "mtime": mtime})
+
+    # Prefer deeper paths first (leaves), then prune ancestors, then sort by recency.
+    items_by_depth = sorted(items, key=lambda d: len(Path(d["path"]).parts), reverse=True)
+    pruned: list[dict[str, Any]] = []
+    kept_paths: list[Path] = []
+    for d in items_by_depth:
+        p = Path(d["path"])
+        if any(str(kp).startswith(str(p) + os.sep) or str(kp) == str(p) for kp in kept_paths):
+            continue
+        pruned.append(d)
+        kept_paths.append(p)
+        if len(pruned) >= limit:
+            break
+
+    pruned.sort(key=lambda d: d["mtime"], reverse=True)
+    return pruned
+
+
+@st.cache_data(ttl=10)
+def cached_list_runs(roots: tuple[str, ...], limit: int = 200) -> list[dict[str, Any]]:
+    """Streamlit-cached wrapper for listing runs.
+
+    Args:
+        roots (tuple[str, ...]): Root directories to scan.
+        limit (int): Maximum number of entries (best-effort).
+
+    Returns:
+        list[dict[str, Any]]: Run metadata entries.
+
+    Notes:
+        The default ttl is short; callers can control refresh by varying inputs or
+        using a session-state bump to re-key calls.
+    """
+    return list_runs_impl(list(roots), limit)
+
+
+def create_min_demo_run(run_dir: Path) -> None:
+    """Create a minimal demo run with required Parquet files.
+
+    Args:
+        run_dir (Path): Target directory to create or populate.
+
+    Returns:
+        None
+
+    Notes:
+        - Creates agents_tokens.parquet with minimal Mesa v3+ schema.
+        - Creates relations.parquet and other_object.parquet with minimal content.
+        - Creates model.parquet with minimal specs.
+    """
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    # Minimal agents_tokens with Mesa v3+ schema (step->t, token_id->o normalization downstream)
+    at = pl.DataFrame(
+        {
+            "step": [0, 0, 1, 1, 2, 2],
+            "agent_id": [0, 1, 0, 1, 0, 1],
+            "token_id": [0, 1, 0, 1, 0, 1],
+            "s_io": [0.1, 0.2, 0.3, 0.25, 0.35, 0.4],
+            "value_score": [0.2, 0.25, 0.3, 0.32, 0.33, 0.36],
+            "y_io": [0, 1, 1, 1, 1, 1],
+            "group": ["A", "A", "A", "B", "B", "B"],
+        }
+    )
+    at.write_parquet(run_dir / "agents_tokens.parquet")
+
+    # Minimal relations and other_object
+    rel = pl.DataFrame({"step": [0, 0], "i": [0, 1], "j": [1, 0], "a_ij": [0.8, -0.3]})
+    rel.write_parquet(run_dir / "relations.parquet")
+
+    bdf = pl.DataFrame(
+        {"step": [0, 0], "i": [0, 0], "j": [1, 1], "o": [0, 1], "b_ijo": [0.5, -0.2]}
+    )
+    bdf.write_parquet(run_dir / "other_object.parquet")
+
+    # Minimal model.parquet for specs
+    model = pl.DataFrame({"seed": [123], "n_agents": [2], "n_tokens": [2], "k": [1], "steps": [3]})
+    model.write_parquet(run_dir / "model.parquet")

--- a/tests/app/test_charts_identity_and_sampling.py
+++ b/tests/app/test_charts_identity_and_sampling.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import polars as pl
+
+from app.charts import apply_ts_sampling, extract_identity_representation
+
+
+def test_extract_identity_representation_slices_and_filters() -> None:
+    # Arrange
+    agent_sel = 0
+    t_sel = 1
+    # at_df with four objects, choose top_o=2 by |s_io| (should pick o=2 and o=3)
+    at_df = pl.DataFrame(
+        {
+            "t": [t_sel] * 4,
+            "agent_id": [agent_sel] * 4,
+            "o": [1, 2, 3, 4],
+            "s_io": [0.1, 0.9, 0.5, 0.2],
+            "rp": [0.01, 0.02, 0.03, 0.04],
+            "rn": [-0.01, -0.02, -0.03, -0.04],
+        }
+    )
+    # rel_df: 3 peers by |a_ij| (top_j=2 should pick j=6 (|0.8|) and j=5 (|0.3|))
+    rel_df = pl.DataFrame(
+        {
+            "t": [t_sel, t_sel, t_sel],
+            "i": [agent_sel, agent_sel, agent_sel],
+            "j": [5, 6, 7],
+            "a_ij": [0.3, -0.8, 0.1],
+        }
+    )
+    # other_df: only entries matching selected (j in {5,6} and o in {2,3}) should remain
+    other_df = pl.DataFrame(
+        {
+            "t": [t_sel] * 5,
+            "i": [agent_sel] * 5,
+            "j": [5, 6, 42, 6, 5],
+            "o": [2, 3, 99, 1, 3],
+            "b_ijo": [0.2, -0.1, 1.0, 0.0, 0.7],
+        }
+    )
+    # oo_df: only pairs among {2,3} should remain
+    oo_df = pl.DataFrame(
+        {
+            "t": [t_sel] * 4,
+            "i": [agent_sel] * 4,
+            "o": [2, 2, 3, 1],
+            "op": [3, 1, 2, 2],
+            "r_oo": [0.4, 0.9, 0.5, 0.8],
+        }
+    )
+
+    # Act
+    out = extract_identity_representation(
+        at_df=at_df,
+        rel_df=rel_df,
+        other_df=other_df,
+        oo_df=oo_df,
+        agent_sel=agent_sel,
+        t_sel=t_sel,
+        top_o=2,
+        top_j=2,
+    )
+
+    # Assert objects contain only top 2 by |s_io| (o=2,3)
+    objs = {(row["o"], row["s_io"]) for row in out["objects"]}
+    assert {2, 3} == {o for (o, _) in objs}
+    # Assert others contain top 2 by |a_ij| (j=6 and j=5), with weights preserved
+    others_js = {row["j"] for row in out["others"]}
+    assert others_js == {5, 6}
+    # b_ijo contains only pairs with selected j and selected o set
+    b_pairs = {(row["j"], row["o"]) for row in out["b_ijo"]}
+    assert b_pairs.issubset({(5, 2), (5, 3), (6, 2), (6, 3)})
+    assert (6, 1) not in b_pairs  # filtered out (o=1 not selected)
+    # object_object contains only pairs among selected {2,3}
+    oo_pairs = {(row["o"], row["op"]) for row in out["object_object"]}
+    assert oo_pairs.issubset({(2, 3), (3, 2)})
+
+
+def test_apply_ts_sampling_stride_and_max_points() -> None:
+    # 100 rows with increasing t
+    df = pl.DataFrame({"t": list(range(100)), "x": list(range(100))})
+    # Stride 10 should produce approximately 10 rows (exact for 100)
+    df_stride = apply_ts_sampling(df, stride=10)
+    assert 8 <= df_stride.height <= 12  # allow small tolerance
+    # Max points enforces a cap (<= requested)
+    df_cap = apply_ts_sampling(df, max_points=7)
+    assert 1 <= df_cap.height <= 7

--- a/tests/app/test_helpers_module.py
+++ b/tests/app/test_helpers_module.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+
+import polars as pl
+
+from app.ui.helpers import compute_overview_kpis, format_ts, humanize_ago
+
+
+def test_humanize_ago_and_format_ts_smoke() -> None:
+    now = time.time()
+    assert "ago" in humanize_ago(now - 2)
+    assert isinstance(format_ts(now), str) and len(format_ts(now)) >= 10
+
+
+def test_compute_overview_kpis_uses_final_t_and_aggregates_mean_and_hold_rate() -> None:
+    # Two timesteps; final timestep has two rows to verify mean and holdings rate aggregation.
+    df = pl.DataFrame(
+        {
+            "t": [0, 1, 1],
+            "value_score": [0.10, 0.30, 0.50],
+            "y_io": [0, 1, 0],
+        }
+    )
+    kpi = compute_overview_kpis(df)
+    # Final t = 1; mean(value_score) = (0.30 + 0.50)/2 = 0.40; hold rate = mean([1,0]) = 0.5
+    assert abs(kpi["final_mean_value"] - 0.40) < 1e-9
+    assert abs(kpi["final_hold_rate"] - 0.50) < 1e-9
+
+
+def test_compute_overview_kpis_handles_missing_columns_gracefully() -> None:
+    # Missing value_score and y_io should yield zeros without raising.
+    df = pl.DataFrame({"t": [0, 1], "agent_id": [0, 0]})
+    kpi = compute_overview_kpis(df)
+    assert kpi == {"final_mean_value": 0.0, "final_hold_rate": 0.0}

--- a/tests/app/test_main_cli.py
+++ b/tests/app/test_main_cli.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app import main as app_main
+
+
+def test_main_renders_inline(monkeypatch, tmp_path) -> None:
+    called = {}
+
+    def fake_streamlit_app(*, default_run=None, default_roots=None, default_watch_ttl=None):
+        called["default_run"] = default_run
+        called["default_roots"] = default_roots
+        called["default_watch_ttl"] = default_watch_ttl
+
+    monkeypatch.setenv("STREAMLIT_SERVER_PORT", "1")
+    # Patch the imported symbol used inside app.main (not the package attribute)
+    monkeypatch.setattr(app_main, "streamlit_app", fake_streamlit_app, raising=True)
+
+    app_main.main(["--run", str(tmp_path), "--watch-ttl", "7"])
+
+    assert called["default_run"] == str(tmp_path)
+    assert called["default_roots"] is None
+    assert called["default_watch_ttl"] == 7
+
+
+def test_main_execs_streamlit(monkeypatch, tmp_path) -> None:
+    # Ensure not in Streamlit context
+    monkeypatch.delenv("STREAMLIT_SERVER_PORT", raising=False)
+
+    captured = {}
+
+    def fake_execv(exe: str, cmd: list[str]) -> None:
+        captured["exe"] = exe
+        captured["cmd"] = cmd
+        # Prevent process handoff
+        raise SystemExit
+
+    monkeypatch.setattr(os, "execv", fake_execv, raising=True)
+
+    with pytest.raises(SystemExit):
+        app_main.main(["--run", str(tmp_path), "--watch-ttl", "3"])
+
+    assert captured["cmd"][0] == captured["exe"]
+    # Assert we launch `python -m streamlit run <path>`
+    assert captured["cmd"][1:4] == ["-m", "streamlit", "run"]
+    # The script path should be the path to app.main
+    expected_main_path = str(Path(app_main.__file__).resolve())
+    assert captured["cmd"][4] == expected_main_path
+    # Passthrough args present after `--`
+    assert "--" in captured["cmd"]
+    dashdash_idx = captured["cmd"].index("--")
+    passthrough = captured["cmd"][dashdash_idx + 1 :]
+    assert passthrough == ["--run", str(tmp_path), "--watch-ttl", "3"]

--- a/tests/app/test_runs_module.py
+++ b/tests/app/test_runs_module.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from app.ui.runs import cached_list_runs, create_min_demo_run, list_runs_impl
+
+
+def _write_min_agents_tokens(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    df = pl.DataFrame(
+        {
+            "step": [0, 1],
+            "agent_id": [0, 0],
+            "token_id": [0, 1],
+            "s_io": [0.1, 0.2],
+            "value_score": [0.2, 0.3],
+            "y_io": [0, 1],
+        }
+    )
+    df.write_parquet(p)
+
+
+def _write_min_model_parquet(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(
+        {"seed": [1], "n_agents": [1], "n_tokens": [2], "k": [1], "steps": [2]}
+    ).write_parquet(p)
+
+
+def test_create_min_demo_run_produces_required_files(tmp_path: Path) -> None:
+    run_dir = tmp_path / "demo_run"
+    create_min_demo_run(run_dir)
+    assert (run_dir / "agents_tokens.parquet").exists()
+    assert (run_dir / "relations.parquet").exists()
+    assert (run_dir / "other_object.parquet").exists()
+    assert (run_dir / "model.parquet").exists()
+
+    # And discovery should find this run under the tmp root
+    runs = list_runs_impl([str(tmp_path)], 200)
+    paths = {r["path"] for r in runs}
+    assert str(run_dir.resolve()) in paths
+
+
+def test_list_runs_impl_prefers_leaf_most_and_prunes_ancestors(tmp_path: Path) -> None:
+    # Create an ancestor directory that is a "run"
+    run_ancestor = tmp_path / "runs" / "A"
+    _write_min_agents_tokens(run_ancestor / "agents_tokens.parquet")
+    _write_min_model_parquet(run_ancestor / "model.parquet")
+
+    # Create a nested child run under the ancestor (deeper path)
+    run_child = run_ancestor / "child"
+    _write_min_agents_tokens(run_child / "agents_tokens.parquet")
+    _write_min_model_parquet(run_child / "model.parquet")
+
+    # Discovery under the common root should include only the deeper leaf (child), not the ancestor
+    runs = list_runs_impl([str(tmp_path)], 200)
+    found = {Path(r["path"]).resolve() for r in runs}
+    assert run_child.resolve() in found
+    assert run_ancestor.resolve() not in found, (
+        "Ancestor should be pruned when a deeper child exists"
+    )
+
+
+@pytest.mark.parametrize("use_model, use_manifest", [(True, False), (False, True), (True, True)])
+def test_list_runs_impl_accepts_runs_with_model_or_manifest(
+    tmp_path: Path, use_model: bool, use_manifest: bool
+) -> None:
+    # Construct a valid run containing agents_tokens and either model.parquet or manifest_*.json
+    run_dir = tmp_path / "valid"
+    _write_min_agents_tokens(run_dir / "agents_tokens.parquet")
+    if use_model:
+        _write_min_model_parquet(run_dir / "model.parquet")
+    if use_manifest:
+        (run_dir / "manifest_any.json").write_text("{}", encoding="utf-8")
+
+    runs = list_runs_impl([str(tmp_path)], 200)
+    paths = {r["path"] for r in runs}
+    assert str(run_dir.resolve()) in paths
+
+
+def test_cached_list_runs_matches_uncached(tmp_path: Path) -> None:
+    # Prepare two runs to exercise ordering and caching
+    r1 = tmp_path / "r1"
+    r2 = tmp_path / "r2"
+    _write_min_agents_tokens(r1 / "agents_tokens.parquet")
+    _write_min_model_parquet(r1 / "model.parquet")
+    _write_min_agents_tokens(r2 / "agents_tokens.parquet")
+    _write_min_model_parquet(r2 / "model.parquet")
+
+    uncached = list_runs_impl([str(tmp_path)], 200)
+    cached = cached_list_runs((str(tmp_path),), 200)
+    # Compare by sorted path sets (ordering by mtime may differ slightly across FS ops)
+    u_paths = sorted({r["path"] for r in uncached})
+    c_paths = sorted({r["path"] for r in cached})
+    assert u_paths == c_paths, (
+        "cached_list_runs should reflect list_runs_impl results for same roots"
+    )


### PR DESCRIPTION
## Summary

Introduce an initial Streamlit app under src/app for quick local visualization of CRV runs. Provides a minimal UI to browse runs and render basic charts to support exploratory analysis and early UX iteration.

## Motivation

Provide a fast path for developers and reviewers to inspect runs without wiring the full viz stack. This scaffolding will evolve as contracts stabilize and align with the planned viz refactor.

## Scope of Changes (by file)

- pyproject.toml (modified): app entry/config adjustments
- pytest.ini (new): test config

- src/app (new):
  - main.py — Streamlit entrypoint
  - data.py — run/data access helpers
  - charts.py — simple chart presenters
  - ui/app.py — page shell and routing
  - ui/header.py — header layout
  - ui/helpers.py — common UI presenters
  - ui/runs.py — runs listing and detail view
  - __init__.py, ui/__init__.py

- tests/app (new):
  - test_main_cli.py
  - test_runs_module.py
  - test_helpers_module.py
  - test_charts_identity_and_sampling.py

## Status

WIP: rough UI and APIs; expect naming/structure to change with upcoming viz alignment.

## Getting started

- uv run streamlit run src/app/main.py

## Verification

- uv run pytest -q tests/app

## Breaking changes

None.