### PR TITLE
docs: add full API reference, strict build, and surfaced module guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,13 +55,10 @@ jobs:
             ${{ runner.os }}-docs-
 
       - name: Sync Python dependencies
-        run: uv sync --frozen --group docs
+        run: uv sync --frozen --extra docs
 
       - name: Install Node dependencies
         run: npm --prefix tools/ebnf ci
-
-      - name: Install repo-only tools package
-        run: uv pip install -e ./tools
 
       - name: Build documentation (DSPy-enabled)
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCS_USE_DSPY: "true"
+      DOCS_DSPY_PROVIDER: "openai"
+      DOCS_DSPY_MODEL: "gpt-4o-mini"
+      DOCS_BASE_URL: "https://docs.ascribe.live"
+      DOCS_DSPY_SEED: "123"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -54,8 +60,26 @@ jobs:
       - name: Install Node dependencies
         run: npm --prefix tools/ebnf ci
 
-      - name: Build documentation
+      - name: Install repo-only tools package
+        run: uv pip install -e ./tools
+
+      - name: Build documentation (DSPy-enabled)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: bash tools/generate_docs.sh
+
+      - name: Assert llms.txt authored by DSPy
+        run: |
+          if [ -n "${{ secrets.OPENAI_API_KEY }}" ]; then
+            if grep -q '^# llms.txt (fallback)' site/llms.txt; then
+              echo "Expected DSPy-authored llms.txt but fallback was emitted."
+              exit 1
+            else
+              echo "DSPy-authored llms.txt verified."
+            fi
+          else
+            echo "No OPENAI_API_KEY secret; skipping DSPy assertion (forks/PRs)."
+          fi
 
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@ out/
 .edsl_cache
 
 tools/ebnf/node_modules/
-
-docs/grammar/ebnf.md
-docs/grammar/diagrams.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,225 @@
+# Contributing to crv_agents
+
+Thanks for contributing! This document defines our contribution standards, with an emphasis on:
+
+- Plan-anchor traceability to our source-of-truth plan(s)
+- Google-style docstrings for Python APIs
+- Small, well-scoped PRs with clear DoR/DoD checklists
+- CI-green, docs-aligned changes
+
+This is a docs/standards-only guide. For architectural scope and acceptance criteria, see:
+
+- plans/crv_relother_rules_oracle_lab_audit_plan.md (source of truth for current phase)
+- plans/crv_mvp_master_plan.md (longer horizon)
+- prompts/\* (module-specific specifications and plans)
+
+## Table of Contents
+
+- Governance & Task Management
+- Definition of Ready (DoR)
+- Definition of Done (DoD)
+- Issue & PR Hygiene
+- Branch Strategy
+- Labels & WIP Limits
+- Docstring Standards (Google style)
+- Acceptable Documentation Targets
+- Test Standards
+- Provenance & Schemas
+
+---
+
+## Governance & Task Management
+
+All work must trace to a plan anchor. Scope is managed in plan files under `plans/`. Do not alter scope or acceptance in code or PR descriptions. Propose scope changes via a dedicated “Plan Change” PR that edits the relevant plan file(s) first.
+
+- Source of Truth: `plans/crv_relother_rules_oracle_lab_audit_plan.md`
+- Work breakdown: One GitHub issue per plan-implementation bullet and per testing group defined in the plan.
+- Sprint Board: Backlog → Ready → In-Progress → PR → Review → Done
+
+Commit to small, reviewable slices that keep the test suite green.
+
+## Definition of Ready (DoR)
+
+Before picking up an issue, ensure:
+
+- Plan anchor is cited with a direct quote of the acceptance or behavior paragraph(s).
+- Acceptance criteria are listed and test targets identified.
+- Schema/data contracts (if any) are enumerated.
+- Owner is assigned; estimation (Fibonacci) is provided.
+- Cross-module impacts are noted (world ↔ mind ↔ lab ↔ viz).
+
+## Definition of Done (DoD)
+
+A PR is “Done” when:
+
+- Code, docstrings, and docs/READMEs are updated to reflect the change.
+- CI is green; tests cover acceptance criteria.
+- Provenance and data contracts validated; schemas documented.
+- PR links plan anchor(s) and includes test evidence (pytest summary, screenshots if UI).
+- No stray TODO/FIXME remain; remaining work is explicitly tracked.
+
+## Issue & PR Hygiene
+
+- Issue Title: `[PLAN:<Section>] <Short task>`  
+  Example: `[PLAN:Observation Rules] Implement GlobalVisibility + registry`
+- Labels:
+  - area(world|mind|lab|viz)
+  - type(feature|test|docs|refactor)
+  - priority(P1|P2|P3)
+  - plan-anchor(<Section>)
+- PR Title: Same format as Issue Title (link issue with “Closes #<id>”).
+- PR Description:
+  - Plan anchor quote(s) and link
+  - Summary of changes and rationale
+  - Schema changes (before/after if applicable)
+  - Perf/latency notes (if relevant)
+  - Test evidence (pytest summary, screenshots if applicable)
+
+## Branch Strategy
+
+- Branch types (examples):
+  - `feature/plan-<anchor-slug>-<short-task>`
+  - `docs/plan-<anchor-slug>-<short-task>`
+  - `test/plan-<anchor-slug>-<short-task>`
+- Keep branches focused and short-lived.
+
+## Labels & WIP Limits
+
+- WIP limits: In-Progress ≤ 4 total; PR ≤ 6 total (across the team).
+- Always move work to Ready only when DoR is satisfied.
+
+## Docstring Standards (Google style)
+
+We use Google-style docstrings for all public Python APIs (modules, classes, functions/methods). Where math is required, include inline formulas that render well on GitHub (e.g., `V = v_base + φ·tanh(γ·U)`).
+
+Example:
+
+```python
+def value_score(self) -> np.ndarray:
+    """Compute bounded valuation per token.
+
+    Uses formal readout: V = v_base + φ·tanh(γ·U) where
+    U mixes identity, valence, direct triads, mediated other–other paths, and semantic spillover.
+
+    Args:
+        None
+
+    Returns:
+        np.ndarray: Valuation vector of shape (K,).
+
+    Notes:
+        - Boundedness: V in (-φ + v_base, +φ + v_base).
+        - Parameters are configured in AgentParams (gamma_readout, phi_readout, alpha_oo, etc.).
+    """
+```
+
+For classes and modules, include a high-level summary, parameter/attribute descriptions, invariants, and examples if applicable.
+
+### Required Sections (as applicable)
+
+- Summary: 1–2 lines describing the purpose and context.
+- Args: Name, type, description, constraints.
+- Returns/Yields: Type(s), shape(s), meaning.
+- Raises: Error conditions with explanations.
+- Notes: Invariants, provenance, performance considerations.
+- Examples: Concise usage snippets relevant to the API.
+
+## Acceptable Documentation Targets
+
+- Markdown-only updates for READMEs and `AGENTS.md` across subpackages (world, mind, lab, viz, and root).
+- No Sphinx/mkdocs scaffolding needed for now (unless explicitly requested).
+- Keep examples executable or near-executable where practical.
+
+## Test Standards
+
+- Keep test suite green. Any change to schemas/exports should include a test to guard the contract.
+- Prefer concise, focused tests with explicit checks on types/shapes and behavior.
+- Use deterministic seeds or deterministic mock engines where relevant (e.g., mock oracle).
+
+## Provenance & Schemas
+
+- Events provenance fields:
+  - `delay` (int|None)
+  - `origin_rule` (str|None)
+- Oracle calls:
+  - Logged to `oracle_calls.parquet` with basic fields (tick, agent*id, render_hash, ctx*\*, value, source, cache_hit, latency_ms, t_enqueued).
+- When you introduce or extend a schema, document the fields and types in module README or inline docstrings, and add tests to guard load/export behavior.
+
+---
+
+## Documentation (build & preview)
+
+The canonical entrypoint for building docs (dev and CI) is the shell script:
+
+```bash
+# Build diagrams and site/ with strict checks
+bash tools/generate_docs.sh
+```
+
+- This script:
+  - Runs the Node-based grammar diagram build (`tools/ebnf`).
+  - Invokes `uv run mkdocs build --strict` (which triggers `tools/build_docs.py` via mkdocs gen-files).
+- Live preview (no diagrams step):
+  ```bash
+  uv run mkdocs serve
+  ```
+
+CI uses the same entrypoint in `.github/workflows/docs.yml` (“Build documentation” step).
+
+### Using DSPy to author llms.txt (local & CI)
+
+We use DSPy to synthesize `llms.txt` during MkDocs generation. A deterministic fallback is used only when DSPy isn’t configured (e.g., no key in forks/PRs).
+
+Local (OpenAI provider)
+
+```bash
+# Enable DSPy authoring
+export DOCS_USE_DSPY=true
+export DOCS_DSPY_PROVIDER=openai
+export DOCS_DSPY_MODEL=gpt-4o-mini
+export OPENAI_API_KEY=sk-...            # Your OpenAI key
+
+# Optional: canonical base URL used in seeds
+export DOCS_BASE_URL=https://docs.ascribe.live
+
+# Optional: reproducibility seed
+export DOCS_DSPY_SEED=123
+
+# Build docs (strict); llms.txt is generated virtually via mkdocs-gen-files
+bash tools/generate_docs.sh
+
+# Verify DSPy path was used (not the fallback):
+head -n 1 site/llms.txt
+# Should NOT equal: "# llms.txt (fallback)"
+```
+
+Future (OpenRouter provider; example only)
+
+```bash
+export DOCS_USE_DSPY=true
+export DOCS_DSPY_PROVIDER=openrouter
+export DOCS_DSPY_MODEL=openrouter/auto
+export OPENROUTER_API_KEY=...           # Your OpenRouter key
+export DOCS_BASE_URL=https://docs.ascribe.live
+bash tools/generate_docs.sh
+```
+
+CI (GitHub Actions)
+
+- The docs workflow `.github/workflows/docs.yml` is configured to:
+  - Set job-level env for DSPy and the canonical base URL:
+    - `DOCS_USE_DSPY=true`, `DOCS_DSPY_PROVIDER=openai`, `DOCS_DSPY_MODEL=gpt-4o-mini`, `DOCS_BASE_URL=https://docs.ascribe.live` (and optional `DOCS_DSPY_SEED`).
+  - Pass `OPENAI_API_KEY` from repo secrets into the build step.
+  - Assert that `llms.txt` was authored by DSPy (fails if the fallback appears) when the secret is available.
+- Maintainers must add a repository secret:
+  - Settings → Secrets and variables → Actions → New repository secret
+  - Name: `OPENAI_API_KEY` (value: your key)
+- Forks/PRs: secrets are not available; the assertion is skipped and the fallback output is acceptable in those runs.
+
+Notes
+
+- All generation uses mkdocs-gen-files (virtual docs). No repo-root writes occur.
+- Switching providers later requires only environment changes; no code edits are necessary.
+- The canonical base for live docs is https://docs.ascribe.live.
+
+By following this guide, your contributions will integrate smoothly with our planning and review processes, remain traceable to plan anchors, and keep the repo consistent and maintainable. If you have questions about these guidelines, open a docs issue tagged `type(docs)` and `plan-anchor(<Section>)`.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,69 @@
+# Getting Started
+
+Follow these steps to set up CRV Agents locally and run a minimal example.
+
+## Prerequisites
+
+- Python 3.13+ (verify: `python3 --version`)
+- uv (Python packaging tool)
+
+Install uv (macOS/Linux):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Or via pipx:
+
+```bash
+pipx install uv
+```
+
+## Clone and install
+
+```bash
+git clone https://github.com/aridyckovsky/crv_agents.git
+cd crv_agents
+uv sync
+```
+
+## Quick start
+
+Run a small demo (see `scripts/` for more examples):
+
+```bash
+uv run python scripts/run_small_sim.py
+```
+
+## Develop/docs locally
+
+Build docs (strict):
+
+```bash
+bash tools/generate_docs.sh
+open site/index.html
+```
+
+## Next steps
+
+### Read the Core contracts and grammar
+
+- [Core](../src/crv/core/README.md)
+- [Grammar (EBNF)](../grammar/ebnf.md)
+- [Grammar Diagrams](../grammar/diagrams.html)
+
+### Explore module guides
+
+- [IO](../src/crv/io/README.md)
+- [Lab](../src/crv/lab/README.md)
+- [Mind](../src/crv/mind/README.md)
+- [World](../src/crv/world/README.md)
+- [Viz](../src/crv/viz/README.md)
+
+## Key Dependencies
+
+- [Polars](https://pola.rs)
+- [Expected Parrot EDSL](https://docs.expectedparrot.com/)
+- [DSPy](https://dspy.ai)
+- [Mesa](https://mesa.readthedocs.io)
+- [Vega-Altair](https://altair-viz.github.io/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# CRV Agents
+
+CRV (Context → Representation → Valuation) is a deterministic, auditable platform for studying social construction of value with agent‑based simulations, typed cognition, and reproducible lab artifacts. This site documents the modules, APIs, and guides for working with the CRV stack.
+
+## At a Glance
+
+- Core contracts and grammar (zero‑IO): enums/EBNF, schemas, table descriptors, hashing/serde, IDs, errors, versioning.
+- Canonical IO layer (append‑only, manifests, partitioning, validation).
+- Lab (personas, scenarios, typed EDSL tasks, offline per‑persona policies, probes/audits).
+- Mind (typed cognition with DSPy; ReAct/mem0/GEPA integration plans).
+- World (ABM kernel with queues, observation rules, valuation pipeline).
+- Viz (read‑only dashboards over Parquet artifacts).
+
+## Quick Links
+
+- [Getting Started](guide/getting-started.md)
+- [Core](src/crv/core/README.md)
+- [IO](src/crv/io/README.md)
+- [Lab](src/crv/lab/README.md)
+- [Mind](src/crv/mind/README.md)
+- [World](src/crv/world/README.md)
+- [Viz](src/crv/viz/README.md)
+
+## Repository Highlights
+
+- Strict data contracts and provenance across boundaries (JSON/Parquet).
+- t+1 barrier and deterministic replay.
+- Append‑only manifests and Run Bundle indexing.
+- Tests for grammar, schemas, IO, and end‑to‑end flows.
+
+To build this site locally (strict):
+
+```bash
+bash tools/generate_docs.sh
+open site/index.html
+```
+
+For a minimal code walkthrough, see the Getting Started guide.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: CRV Agents — Core
+site_name: CRV Agents
 repo_url: https://github.com/aridyckovsky/crv_agents
 theme:
   name: material
@@ -14,23 +14,26 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          paths: [src]
           options:
             docstring_style: google
             show_source: true
             show_root_heading: true
             separate_signature: true
-            preload_modules: [crv.core]
+            inherited_members: true
+            filters: ["!^_"]
+            show_if_no_docstring: true
+            members_order: source
+            group_by_category: true
+            show_signature: true
+            show_signature_annotations: true
+            annotations_path: full
+            show_submodules: false
+            show_object_full_path: false
+            show_root_full_path: false
+            line_length: 88
   - gen-files:
       scripts:
         - tools/build_docs.py
   - literate-nav:
       nav_file: SUMMARY.md
-
-nav:
-  - Overview: index.md
-  - Core:
-      - Contracts (README): src/crv/core/README.md
-      - Grammar (EBNF): grammar/ebnf.md
-      - Grammar diagrams (HTML): grammar/diagrams.html
-  - API:
-      - crv.core: api/crv_core.md

--- a/src/crv/lab/README.md
+++ b/src/crv/lab/README.md
@@ -1,0 +1,160 @@
+# crv.lab — EDSL policy building for CRV
+
+Purpose
+
+- crv.lab encapsulates Expected Parrot EDSL usage to elicit structured judgments and aggregate them into a policy table consumed by the CRV simulator.
+- Outputs include a tidy policy Parquet and a manifest with provenance for replayability and audits.
+
+Module layout
+
+- cli.py — command-line entry points (build-policy, show-policy)
+- policy_builder.py — run orchestration, normalization, aggregation, and stamped artifact writing
+- survey.py — EDSL survey pieces (question, scenarios, agents, models)
+- AGENTS.md — detailed standards and practices for EDSL in this repo
+
+Requirements
+
+- Python 3.13 (project-level setting)
+- uv (>= 0.8) for environment and scripts
+- OPENAI_API_KEY in .env for local runs (Remote Inference is optional)
+- python-dotenv is used to load .env automatically by default
+
+Quick start (mock or local runs)
+
+1. Install and sync:
+   - uv venv
+   - source .venv/bin/activate # Windows: .venv\Scripts\activate
+   - uv sync
+2. (Optional) Configure keys in `.env`:
+   - OPENAI_API_KEY=sk-... # required for `--mode local`
+   - EXPECTED_PARROT_API_KEY=ep-... # required for `--mode remote`
+3. Build a mock policy run (no API keys needed):
+   - uv run crv-lab build-policy --runs-root runs/demo --mode mock --persona persona_baseline --model gpt-4o
+   - Artifacts land under `runs/demo/<STAMP>/` with `raw/`, `tidy/`, `policies/`, and `manifest_*`.
+4. Inspect outputs:
+   - ls runs/demo/<STAMP>/policies/
+   - uv run crv-lab show-policy --policy runs/demo/<STAMP>/policies/policy_crv_one_agent_valuation_v0.1.0.parquet
+
+Remote inference
+
+- Requires an Expected Parrot Coop account and credits.
+- Ensure `EXPECTED_PARROT_API_KEY` is present in `.env` and run:
+  - uv run crv-lab build-policy --runs-root runs/remote --mode remote --persona persona_baseline --model gpt-4o
+- The CLI submits a remote job and records its UUID in the manifest. No policy parquet is written until the job completes; track status in Coop or poll the API before re-running aggregation. Once the job reports `completed` (and the remote cache contains answers), either re-run `crv-lab build-policy --mode local --await-remote ...` to wait for completion inline or call `uv run crv-lab pull-remote --runs-root RUNS_ROOT --stamp STAMP` to download results and materialize the policy in-place.
+- If submission fails (validation error, auth, etc.), the CLI exits non-zero and still writes a manifest capturing the error message for audit. Coop response details (for example, validation fields) are stored under `meta.remote_job` when available.
+- The CLI aborts on validation errors; check the Coop jobs dashboard for details if the run fails.
+
+CLI reference
+
+- Build a policy run:
+  ```
+  uv run crv-lab build-policy --runs-root RUNS_ROOT --mode {mock|local|remote} [--persona P] [--personas-file FILE] [--model M] [--models-file FILE] [--scenarios PATH] [--seed N] [--iterations N] [--stamp STAMP] [--await-remote] [--poll-interval SEC] [--timeout SEC] [--no-env]
+  ```
+- Show a policy:
+  ```
+  uv run crv-lab show-policy --policy path/to/policy.parquet [--n ROWS]
+  ```
+- Pull remote results:
+  ```
+  uv run crv-lab pull-remote --runs-root RUNS_ROOT --stamp STAMP [--job UUID] [--poll-interval SEC] [--timeout SEC]
+  ```
+- Key flags:
+  - `--runs-root`: root directory for stamped runs (default `runs`).
+  - `--mode`: `mock` (deterministic hash answers), `local` (Expected Parrot via local provider SDKs), or `remote` (Expected Parrot Coop jobs).
+  - `--scenarios`: Parquet with required `ctx_*` columns; omit to use the synthetic demo grid.
+  - `--seed`: controls mock hash determinism and manifest provenance.
+  - `--personas-file`: JSON file describing persona traits (used unless overridden by `--persona`).
+  - `--models-file`: JSON file defining model specs (slug, coop slug, provider, notes).
+  - `--iterations`: number of iterations for Coop remote jobs (default `1`).
+  - `--await-remote`: block until the Coop job completes and pull results immediately.
+  - `--poll-interval` / `--timeout`: polling cadence and timeout when awaiting completion.
+  - `--no-env`: skip loading `.env` before resolving credentials.
+  - `--print-manifest`: echo the manifest path on completion.
+  - Remote mode writes only a submission manifest until results are downloaded. Use `--await-remote` or `crv-lab pull-remote` to materialize tidy/policy files once the job finishes.
+
+Survey components
+
+- Question (`surveys.py`): Linear 1–7 Likert with ctx variables (`ctx_token_kind`, `ctx_owner_status`, `ctx_peer_alignment`, plus social/affect cues).
+- Scenarios (`scenarios.py`): ScenarioList built from Polars frames with extended context columns (`ctx_*`). Optional JSON overrides can enrich defaults.
+- Personas (`personas.py`): Structured persona definitions with traits/notes, serialized into manifests.
+- Models (`modelspec.py`): Coop-compatible model slug mapping, provider metadata, and notes.
+
+Outputs and data contracts
+
+- Run directory layout: `RUNS_ROOT/<STAMP>/`
+  - `raw/raw_<survey_id>.parquet`
+  - `tidy/tidy_<survey_id>.parquet`
+  - `policies/policy_<survey_id>.parquet`
+  - `manifest_<survey_id>.json`
+- Tidy table schema extends the AGENTS contract with `prompt_hash` and additional context fields (`ctx_salient_other_alignment`, `ctx_recent_affect`, `ctx_group_label`).
+- Policy schema:
+  - ctx_token_kind, ctx_owner_status, ctx_peer_alignment, ctx_salient_other_alignment, ctx_recent_affect, ctx_group_label, persona, model, value_mean, value_sd, n
+- Manifest JSON captures:
+  - `timestamp`, `survey_id`, `run_stamp`, `runs_root`, git commit, edsl version
+  - Execution metadata (`mode`, seeds, persona/model lists, persona trait summaries, model metadata, iterations, scenario source, prompt hash count, key presence, raw/tidy/policy paths, optional EDSL job ids)
+  - Remote submissions additionally record the remote job payload and UUID; tidy/policy paths are omitted until aggregation is rerun.
+
+Troubleshooting
+
+- “QuestionScenarioRenderError: variables still present”:
+  - Ensure the question template uses ctx.\* variables (e.g., ctx.ctx_token_kind).
+  - Ensure scenarios are constructed with ScenarioList.from_list("ctx", ...).
+- “EDSL results missing ctx columns”:
+  - The build now tries to extract ctx\__ from typical shapes (scenario._, scenario.ctx.\*, top-level ctx struct).
+  - If ctx\_\* columns still don’t appear but row count matches the expected grid, positional alignment is applied to produce a valid tidy table.
+- “Validation Error” on remote runs:
+  - This often indicates a routing/registry issue or a provider-side constraint; check the Coop Jobs page for the full validator error.
+  - For development, prefer `--mode local` with `OPENAI_API_KEY` set in `.env`.
+- No keys found:
+  - The CLI auto-loads `.env`; pass `--no-env` to disable. Ensure `.env` contains `OPENAI_API_KEY` for local runs and `EXPECTED_PARROT_API_KEY` for remote runs.
+
+Contributing
+
+- Keep survey.py conservative and readable:
+  - Canonical variable names and ctx namespace.
+  - Avoid provider-specific switches and keep model slugs simple.
+- Bump SURVEY_ID if changing question wording or scenario schema.
+- Add/extend tests in tests/ to cover normalization, schema, and determinism.
+- Run the standard checks before pushing:
+  - uv run ruff
+  - uv run mypy --strict
+  - uv run pytest -q
+- No pandas in library code; use Polars for data frames and Arrow via to_pandas() only at EDSL boundaries.
+- Keep outputs deterministic and reproducible; manifests must include seeds and versions.
+
+Examples
+
+- Deterministic mock run:
+  - uv run crv-lab build-policy --runs-root runs/demo --mode mock --persona persona_baseline --model gpt-4o
+- Local EDSL execution (requires OPENAI_API_KEY):
+  - uv run crv-lab build-policy --runs-root runs/local --mode local --persona persona_baseline --model gpt-4o
+- Remote submission (await completion):
+  - uv run crv-lab build-policy --runs-root runs/remote --mode remote --persona persona_baseline --model gpt-4o --await-remote
+- Remote submission (deferred pull):
+  - uv run crv-lab build-policy --runs-root runs/remote --mode remote --persona persona_baseline --model gpt-4o
+  - uv run crv-lab pull-remote --runs-root runs/remote --stamp <STAMP>
+- Custom scenario grid:
+  - uv run crv-lab build-policy --runs-root runs/scenarios --mode mock --scenarios data/my_scenarios.parquet
+- EDSL docs (Surveys, Scenarios, Agents, Models, Results)
+- Inspect output:
+  - uv run crv-lab show-policy --policy runs/demo/<STAMP>/policies/policy_crv_one_agent_valuation_v0.1.0.parquet
+
+Run Bundle integration and audit
+
+- Lab helpers write artifacts to <root>/runs/<run_id>/artifacts/lab/{tidy,probes,policy,audit}/
+- Examples:
+  - python scripts/lab_probe_and_audit.py --run-id lab_demo
+  - python scripts/lab_probe_and_audit.py --run-id lab_demo --root-dir /tmp/crv_out --rows 8
+- The script resolves IoSettings.load() precedence (env > TOML > defaults) and refreshes bundle.manifest.json for discoverability.
+
+References
+
+- EDSL docs (Surveys, Scenarios, Agents, Models, Results)
+
+- EDSL docs (Surveys, Scenarios, Agents, Models, Results)
+- Expected Parrot Remote Inference docs (setup, jobs, credits)
+- AGENTS.md in this directory for our internal style and contracts
+
+Notes
+
+- This module intentionally favors a minimal, robust local flow (gpt-4o + OPENAI_API_KEY) and adds only the normalization needed to stabilize outputs across EDSL versions and backends. Remote inference is optional and can be enabled later without changing your local workflow.

--- a/src/crv/mind/README.md
+++ b/src/crv/mind/README.md
@@ -1,0 +1,36 @@
+# CRV Mind
+
+The Mind module hosts reasoning/oracle components and program interfaces used by agents and pipelines.
+
+What it provides
+
+- Oracle interfaces and types for model-backed reasoning
+- Program compilation/execution helpers
+- Controller utilities for ReAct-style flows
+- Common signatures and data types shared across mind components
+
+Quick start
+
+- Install dependencies with uv (or pip):
+  ```bash
+  uv sync
+  ```
+- Minimal usage (Python):
+
+  ```python
+  # Example: import mind components
+  from crv.mind.oracle import Oracle  # concrete oracle(s)
+  from crv.mind.signatures import Thought, Action  # shared types
+
+  # Stub construction for demonstration; see API Reference for details
+  # oracle = Oracle.from_config(...)
+  # result = oracle.ask("What should the agent do next?")
+  # print(result)
+  ```
+
+Next steps
+
+- Read the API Reference for module details:
+  - crv.mind (package index)
+  - Submodules (oracle, oracle_types, programs, react_controller, signatures)
+- Explore the Guide’s Getting Started for setup and workflow context.

--- a/src/crv/world/README.md
+++ b/src/crv/world/README.md
@@ -1,0 +1,41 @@
+# CRV World
+
+The World module defines the simulation environment: agents, events, configuration, and runtime model orchestration.
+
+What it provides
+
+- Agent model and roster management
+- Event envelopes and scheduling
+- World configuration and model wiring
+- Observation rules and visibility policies
+- Simulation loop utilities
+
+Quick start
+
+- Install dependencies with uv (or pip):
+  ```bash
+  uv sync
+  ```
+- Minimal usage (Python):
+
+  ```python
+  # Example imports from the world module
+  from crv.world.model import CRVModel
+  from crv.world.config import WorldConfig
+  from crv.world.agents import CRVAgent
+
+  # Construct a small model (illustrative)
+  cfg = WorldConfig()
+  agents = [CRVAgent(index=i) for i in range(3)]
+  model = CRVModel(config=cfg, agents=agents)
+
+  # Step the model (see API Reference for details)
+  # model.step()
+  ```
+
+Next steps
+
+- See API Reference for detailed types and APIs:
+  - crv.world (package index)
+  - Submodules (agents, config, data, events, model, observation_rules, sim, sweep)
+- Review the Guide’s Getting Started for setup and workflow context.

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import mkdocs_gen_files
+import mkdocs_gen_files  # type: ignore[import-not-found]
 
 ROOT = Path(__file__).resolve().parents[1]
 p = Path("src/crv/core/core.ebnf")
@@ -39,13 +39,154 @@ if core_readme.exists():
         f.write(core_readme.read_text(encoding="utf-8"))
     mkdocs_gen_files.set_edit_path(target_core_readme, "src/crv/core/README.md")
 
+# Surface IO README in docs (if present)
+io_readme = ROOT / "src" / "crv" / "io" / "README.md"
+if io_readme.exists():
+    target_io_readme = Path("src/crv/io/README.md")
+    with mkdocs_gen_files.open(target_io_readme, "w") as f:
+        f.write(io_readme.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(target_io_readme, "src/crv/io/README.md")
+
+# Surface Lab README in docs (if present)
+lab_readme = ROOT / "src" / "crv" / "lab" / "README.md"
+if lab_readme.exists():
+    target_lab_readme = Path("src/crv/lab/README.md")
+    with mkdocs_gen_files.open(target_lab_readme, "w") as f:
+        f.write(lab_readme.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(target_lab_readme, "src/crv/lab/README.md")
+
+# Surface Viz README in docs (if present)
+viz_readme = ROOT / "src" / "crv" / "viz" / "README.md"
+if viz_readme.exists():
+    target_viz_readme = Path("src/crv/viz/README.md")
+    with mkdocs_gen_files.open(target_viz_readme, "w") as f:
+        f.write(viz_readme.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(target_viz_readme, "src/crv/viz/README.md")
+
+# Surface Mind README in docs (if present)
+mind_readme = ROOT / "src" / "crv" / "mind" / "README.md"
+if mind_readme.exists():
+    target_mind_readme = Path("src/crv/mind/README.md")
+    with mkdocs_gen_files.open(target_mind_readme, "w") as f:
+        f.write(mind_readme.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(target_mind_readme, "src/crv/mind/README.md")
+
+# Surface World README in docs (if present)
+world_readme = ROOT / "src" / "crv" / "world" / "README.md"
+if world_readme.exists():
+    target_world_readme = Path("src/crv/world/README.md")
+    with mkdocs_gen_files.open(target_world_readme, "w") as f:
+        f.write(world_readme.read_text(encoding="utf-8"))
+    mkdocs_gen_files.set_edit_path(target_world_readme, "src/crv/world/README.md")
+
 pyproject = ROOT / "pyproject.toml"
 if pyproject.exists():
     pyproject_doc = Path("pyproject.toml")
     with mkdocs_gen_files.open(pyproject_doc, "w") as f:
         f.write(pyproject.read_text(encoding="utf-8"))
 
-# 2) API entry
-api_md = Path("api/crv_core.md")
-with mkdocs_gen_files.open(api_md, "w") as f:
-    f.write("# `crv.core` API\n\n::: crv.core\n")
+# 2) API Reference: generate a full module tree for crv.* packages
+PACKAGES = ["core", "io", "lab", "mind", "viz", "world"]
+
+# Generate a minimal Getting Started page under Guide
+getting_started_md = Path("guide/getting-started.md")
+getting_started_md.parent.mkdir(parents=True, exist_ok=True)
+with mkdocs_gen_files.open(getting_started_md, "w") as f:
+    f.write(
+        "# Getting Started\n\n"
+        "Follow these steps to set up CRV Agents locally and run a minimal example.\n\n"
+        "## Prerequisites\n\n"
+        "- Python 3.13+ (verify: `python3 --version`)\n"
+        "- uv (Python packaging tool)\n\n"
+        "Install uv (macOS/Linux):\n\n"
+        "```bash\n"
+        "curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+        "```\n"
+        "Or via pipx:\n"
+        "```bash\n"
+        "pipx install uv\n"
+        "```\n\n"
+        "## Clone and install\n\n"
+        "```bash\n"
+        "git clone https://github.com/aridyckovsky/crv_agents.git\n"
+        "cd crv_agents\n"
+        "uv sync\n"
+        "```\n\n"
+        "## Quick start\n\n"
+        "Run a small demo (see scripts/ for more examples):\n"
+        "```bash\n"
+        "uv run python scripts/run_small_sim.py\n"
+        "```\n\n"
+        "## Develop/docs locally\n\n"
+        "Build docs (strict):\n"
+        "```bash\n"
+        "bash tools/generate_docs.sh\n"
+        "```\n\n"
+        "## Next steps\n\n"
+        "- Read the Core contracts and grammar.\n"
+        "- Explore module guides for IO, Lab, Viz, Mind, and World.\n"
+    )
+
+summary_lines: list[str] = []
+# Define full top-level nav via literate-nav (overrides mkdocs.yaml nav)
+summary_lines.extend(
+    [
+        "- [Overview](index.md)",
+        "- Guide",
+        "    - [Getting Started](guide/getting-started.md)",
+        "    - Core",
+        "        - [Contracts (README)](src/crv/core/README.md)",
+        "        - [Grammar (EBNF)](grammar/ebnf.md)",
+        "        - [Grammar diagrams (HTML)](grammar/diagrams.html)",
+        "    - [IO](src/crv/io/README.md)",
+        "    - [Lab](src/crv/lab/README.md)",
+        "    - [Viz](src/crv/viz/README.md)",
+        "    - [Mind](src/crv/mind/README.md)",
+        "    - [World](src/crv/world/README.md)",
+        "- API Reference",
+    ]
+)
+
+for pkg in PACKAGES:
+    pkg_dir = ROOT / "src" / "crv" / pkg
+    if not pkg_dir.exists():
+        continue
+
+    pkg_import = f"crv.{pkg}"
+
+    # Package index page
+    pkg_index_md = Path(f"api/crv/{pkg}/index.md")
+    pkg_index_md.parent.mkdir(parents=True, exist_ok=True)
+    with mkdocs_gen_files.open(pkg_index_md, "w") as f:
+        f.write(f"# `{pkg_import}` API\n\n")
+        f.write("See the module pages listed in the navigation.\n")
+    # Link edit path to the package __init__.py if present
+    init_path = Path(f"src/crv/{pkg}/__init__.py")
+    if init_path.exists():
+        mkdocs_gen_files.set_edit_path(pkg_index_md, init_path.as_posix())
+
+    # SUMMARY: top-level entry for the package
+    summary_lines.append(f"    - [{pkg_import}]({pkg_index_md.as_posix()})")
+
+    # Walk all modules in the package
+    for py_file in sorted(pkg_dir.rglob("*.py")):
+        if py_file.name == "__init__.py":
+            continue
+
+        rel_from_src = py_file.relative_to(ROOT / "src")  # e.g., crv/io/read.py
+        import_path = ".".join(rel_from_src.with_suffix("").parts)  # e.g., crv.io.read
+
+        # Destination doc path mirrors the python module path under api/
+        doc_path = Path("api") / rel_from_src.with_suffix(".md")
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with mkdocs_gen_files.open(doc_path, "w") as f:
+            f.write(f"# `{import_path}`\n\n::: {import_path}\n")
+        mkdocs_gen_files.set_edit_path(doc_path, rel_from_src.as_posix())
+
+        leaf_name = import_path.split(".")[-1]
+        summary_lines.append(f"        - [{leaf_name}]({doc_path.as_posix()})")
+
+# 3) Write SUMMARY.md for literate-nav with just the API section
+with mkdocs_gen_files.open("SUMMARY.md", "w") as f:
+    f.write("\n".join(summary_lines) + "\n")

--- a/tools/docs_llms.py
+++ b/tools/docs_llms.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+@dataclass(frozen=True)
+class PageRef:
+    title: str
+    # Path within the docs site (MkDocs virtual docs), e.g., "guide/getting-started.md"
+    path: str
+
+
+@dataclass(frozen=True)
+class ExternalLink:
+    title: str
+    url: str
+
+
+@dataclass(frozen=True)
+class LLMSConfig:
+    site_name: str
+    base_url: str | None
+    allow_patterns: list[str]
+    disallow_patterns: list[str]
+    notes: str | None = None
+
+
+def gather_core_pages() -> list[PageRef]:
+    # Curated, site-relative targets that our build already emits (no crawling).
+    # Some entries are conditionally present based on surfaced READMEs; including
+    # them here keeps the generator DRY and centralized.
+    return [
+        PageRef("Overview", "index.md"),
+        PageRef("Getting Started", "guide/getting-started.md"),
+        PageRef("Grammar (EBNF)", "grammar/ebnf.md"),
+        PageRef("Grammar Diagrams", "grammar/diagrams.html"),
+        # Package guides (conditionally included if surfaced by build_docs)
+        PageRef("Core", "src/crv/core/README.md"),
+        PageRef("IO", "src/crv/io/README.md"),
+        PageRef("Lab", "src/crv/lab/README.md"),
+        PageRef("Mind", "src/crv/mind/README.md"),
+        PageRef("World", "src/crv/world/README.md"),
+        PageRef("Viz", "src/crv/viz/README.md"),
+        # API top sections (directories rendered by MkDocs; useful as sections)
+        PageRef("API: crv.core", "api/crv/core/"),
+        PageRef("API: crv.io", "api/crv/io/"),
+        PageRef("API: crv.lab", "api/crv/lab/"),
+        PageRef("API: crv.mind", "api/crv/mind/"),
+        PageRef("API: crv.viz", "api/crv/viz/"),
+        PageRef("API: crv.world", "api/crv/world/"),
+    ]
+
+
+def gather_external_links() -> list[ExternalLink]:
+    return [
+        ExternalLink("Expected Parrot EDSL", "https://docs.expectedparrot.com/"),
+        ExternalLink("DSPy", "https://dspy.ai"),
+        ExternalLink("Polars", "https://pola.rs"),
+        ExternalLink("Mesa", "https://mesa.readthedocs.io"),
+    ]
+
+
+def _format_seed_url(base_url: str | None, doc_path: str) -> str:
+    """
+    Convert a docs path to the built site's pretty URL:
+    - "*.md" -> strip extension, add trailing slash (index.md -> "/")
+    - "*.html" and directory paths keep as-is
+    """
+    p = doc_path.strip("/")
+    rel: str
+    if p.endswith(".md"):
+        if p == "index.md":
+            rel = ""
+        else:
+            rel = p[:-3] + "/"
+    else:
+        # Keep .html or directory paths unchanged
+        rel = p
+
+    if base_url:
+        return f"{base_url.rstrip('/')}/{rel}"
+    return f"/{rel}"
+
+
+def _bool_env(name: str, default: bool = True) -> bool:
+    v = os.getenv(name)
+    if v is None:
+        return default
+    return v.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _configure_dspy_from_env() -> tuple[object | None, str | None]:
+    """
+    Try to import and configure DSPy from environment variables.
+    Returns (dspy_module_or_None, error_message_or_None).
+    """
+    try:
+        load_dotenv()
+        import dspy  # type: ignore
+    except Exception:
+        return None, "dspy import failed"
+
+    if not _bool_env("DOCS_USE_DSPY", True):
+        return None, "DOCS_USE_DSPY disabled"
+
+    model = os.getenv("DOCS_DSPY_MODEL")
+    provider = (os.getenv("DOCS_DSPY_PROVIDER") or "openai").lower()
+
+    try:
+        lm = None
+        if provider == "openai":
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not (model and api_key):
+                return None, "missing OPENAI_API_KEY or DOCS_DSPY_MODEL"
+            try:
+                lm = dspy.OpenAI(model=model, api_key=api_key)  # type: ignore[attr-defined]
+            except Exception:
+                try:
+                    # DSPy >=3 unified LM API
+                    lm = dspy.LM(f"openai/{model}", api_key=api_key)  # type: ignore[attr-defined]
+                except Exception:
+                    return None, "failed to configure OpenAI LM"
+        elif provider == "openrouter":
+            api_key = os.getenv("OPENROUTER_API_KEY")
+            if not (model and api_key):
+                return None, "missing OPENROUTER_API_KEY or DOCS_DSPY_MODEL"
+            try:
+                if hasattr(dspy, "OpenRouter"):
+                    lm = dspy.OpenRouter(model=model, api_key=api_key)  # type: ignore[attr-defined]
+                else:
+                    lm = dspy.LM(f"openrouter/{model}", api_key=api_key)  # type: ignore[attr-defined]
+            except Exception:
+                return None, "failed to configure OpenRouter LM"
+        elif provider == "ollama":
+            # Local inference endpoint if available
+            try:
+                if hasattr(dspy, "Ollama"):
+                    lm = dspy.Ollama(model=model or "llama3")  # type: ignore[attr-defined]
+                else:
+                    lm = dspy.LM(f"ollama/{model or 'llama3'}")  # type: ignore[attr-defined]
+            except Exception:
+                return None, "failed to configure Ollama LM"
+        else:
+            return None, f"unsupported provider: {provider}"
+
+        dspy.settings.configure(lm=lm)
+        seed = os.getenv("DOCS_DSPY_SEED")
+        if seed and seed.isdigit():
+            try:
+                import random
+
+                random.seed(int(seed))
+            except Exception:
+                # Non-fatal
+                pass
+        return dspy, None
+    except Exception as e:
+        return None, str(e)
+
+
+def render_llms_txt_dspy(
+    cfg: LLMSConfig, pages: list[PageRef], externals: list[ExternalLink]
+) -> str | None:
+    """
+    Attempt to synthesize llms.txt using DSPy if available. Falls back to None
+    on import or runtime errors so the caller can provide a non-DSPy path.
+    """
+    try:
+        dspy, _err = _configure_dspy_from_env()
+        if not dspy:
+            return None
+
+        ds: Any = dspy
+
+        # Prepare structured inputs for the DSPy program
+        allow_lines = "\n".join(f"Allow: {pat}" for pat in (cfg.allow_patterns or []))
+        disallow_lines = "\n".join(f"Disallow: {pat}" for pat in (cfg.disallow_patterns or []))
+        seeds_markdown = "\n".join(
+            f"- {p.title}: {_format_seed_url(cfg.base_url, p.path)}" for p in pages
+        )
+        references_markdown = "\n".join(f"- {e.title}: {e.url}" for e in externals)
+        notes = cfg.notes or ""
+
+        # Define signature and author module inline to avoid hard dependency at import time
+        class WriteLLMSTxt(ds.Signature):  # type: ignore[name-defined]
+            """
+            Write a complete llms.txt for an LLM-friendly site crawl, inspired by the DSPy tutorial.
+
+            Requirements:
+            - Output plain text (no markdown code fences), suitable as llms.txt.
+            - Begin with: "User-agent: *"
+            - Include one line per allow/disallow, exactly prefixed with "Allow:" or "Disallow:".
+            - Include a "Seeds" section as a markdown-style bullet list using the provided seeds_markdown verbatim.
+            - Include an "External references" section as a bullet list using references_markdown verbatim.
+            - If notes is non-empty, include a "Notes" section and include notes as plain text.
+            - Do not invent URLs. Use inputs as given.
+            """
+
+            site_name: str = ds.InputField(desc="Human-readable site name.")
+            base_url: str = ds.InputField(desc="Base URL (may be empty if unknown).")
+            allow_lines: str = ds.InputField(desc='Lines like "Allow: /path" (may be empty).')
+            disallow_lines: str = ds.InputField(desc='Lines like "Disallow: /path" (may be empty).')
+            seeds_markdown: str = ds.InputField(desc='Bullet list "- Title: URL" lines.')
+            references_markdown: str = ds.InputField(desc='Bullet list "- Name: URL" lines.')
+            notes: str = ds.InputField(desc="Optional notes; may be empty.")
+            llms_txt: str = ds.OutputField(desc="Final llms.txt content.")
+
+        class LLMSAuthor(ds.Module):  # type: ignore[name-defined]
+            def __init__(self) -> None:
+                super().__init__()
+                self.write = ds.Predict(WriteLLMSTxt)
+
+            def forward(
+                self,
+                site_name: str,
+                base_url: str,
+                allow_lines: str,
+                disallow_lines: str,
+                seeds_markdown: str,
+                references_markdown: str,
+                notes: str,
+            ) -> str:
+                out = self.write(
+                    site_name=site_name,
+                    base_url=base_url or "",
+                    allow_lines=allow_lines,
+                    disallow_lines=disallow_lines,
+                    seeds_markdown=seeds_markdown,
+                    references_markdown=references_markdown,
+                    notes=notes,
+                )
+                return out.llms_txt
+
+        author = LLMSAuthor()
+        txt = author(
+            site_name=cfg.site_name,
+            base_url=(cfg.base_url or ""),
+            allow_lines=allow_lines,
+            disallow_lines=disallow_lines,
+            seeds_markdown=seeds_markdown,
+            references_markdown=references_markdown,
+            notes=notes,
+        ).strip()
+
+        # Normalize formatting: strip any accidental code fences and ensure newline
+        if "```" in txt:
+            txt = txt.replace("```", "").strip()
+        if not txt.endswith("\n"):
+            txt += "\n"
+
+        return txt
+    except Exception:
+        return None
+
+
+def render_llms_txt_fallback(
+    cfg: LLMSConfig, pages: list[PageRef], externals: list[ExternalLink]
+) -> str:
+    lines: list[str] = []
+    lines.append("# llms.txt (fallback)\n")
+    lines.append("User-agent: *\n")
+    if cfg.allow_patterns:
+        for pat in cfg.allow_patterns:
+            lines.append(f"Allow: {pat}\n")
+    if cfg.disallow_patterns:
+        for pat in cfg.disallow_patterns:
+            lines.append(f"Disallow: {pat}\n")
+
+    lines.append("\n# Seeds\n")
+    for p in pages:
+        lines.append(f"- {p.title}: {_format_seed_url(cfg.base_url, p.path)}\n")
+
+    lines.append("\n# External references\n")
+    for e in externals:
+        lines.append(f"- {e.title}: {e.url}\n")
+
+    if cfg.notes:
+        lines.append(f"\n# Notes\n{cfg.notes}\n")
+
+    return "".join(lines)
+
+
+def build_llms_txt(site_name: str, base_url: str | None) -> str:
+    cfg = LLMSConfig(
+        site_name=site_name,
+        base_url=base_url,
+        allow_patterns=["/"],
+        disallow_patterns=[],
+        notes=("This file guides LLM crawlers. Prefer stable URLs and avoid rate limits."),
+    )
+    pages = gather_core_pages()
+    externals = gather_external_links()
+    text = render_llms_txt_dspy(cfg, pages, externals)
+    if text:
+        return text
+    # If DSPy output is required, fail the build rather than silently falling back.
+    # Set DOCS_DSPY_REQUIRED=true to enforce this in local dev or CI.
+    if _bool_env("DOCS_DSPY_REQUIRED", False):
+        raise RuntimeError("DSPy generation required but unavailable or failed")
+    return render_llms_txt_fallback(cfg, pages, externals)
+
+
+__all__ = [
+    "PageRef",
+    "ExternalLink",
+    "LLMSConfig",
+    "gather_core_pages",
+    "gather_external_links",
+    "render_llms_txt_dspy",
+    "render_llms_txt_fallback",
+    "build_llms_txt",
+]

--- a/tools/ebnf/package.json
+++ b/tools/ebnf/package.json
@@ -2,8 +2,5 @@
   "private": true,
   "devDependencies": {
     "ebnf2railroad": "^1.14.0"
-  },
-  "scripts": {
-    "diagrams": "ebnf2railroad -t \"CRV Core Grammar Diagrams\" ../../src/crv/core/core.ebnf -o ../../docs/grammar/diagrams.html"
   }
 }

--- a/tools/generate_docs.sh
+++ b/tools/generate_docs.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 # Canonical docs build entrypoint for dev and CI.
 # - Grammar EBNF markdown is generated via tools/build_docs.py (mkdocs gen-files) at build time.
-# - This script handles Node-based diagram generation and runs the strict mkdocs build.
+# - Ensures Node deps are available; diagrams are generated during mkdocs gen-files. Runs strict mkdocs build.
 set -euo pipefail
 
-# Build EBNF diagrams (Node step)
+# Ensure Node deps for diagrams CLI (ebnf2railroad) are installed; actual generation happens in mkdocs gen-files
 if [ -d tools/ebnf/node_modules ]; then
-  npm --prefix tools/ebnf run diagrams
+  npm --prefix tools/ebnf ci
 else
   npm --prefix tools/ebnf ci
-  npm --prefix tools/ebnf run diagrams
 fi
 
 # Strict MkDocs build (gen-files runs tools/build_docs.py during build)

--- a/tools/generate_docs.sh
+++ b/tools/generate_docs.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# TODO: This naming is off, need to consider difference wiht build_docs.py
+# Canonical docs build entrypoint for dev and CI.
+# - Grammar EBNF markdown is generated via tools/build_docs.py (mkdocs gen-files) at build time.
+# - This script handles Node-based diagram generation and runs the strict mkdocs build.
 set -euo pipefail
 
-uv run python tools/generate_ebnf_md.py
+# Build EBNF diagrams (Node step)
 if [ -d tools/ebnf/node_modules ]; then
   npm --prefix tools/ebnf run diagrams
 else
@@ -10,4 +12,5 @@ else
   npm --prefix tools/ebnf run diagrams
 fi
 
+# Strict MkDocs build (gen-files runs tools/build_docs.py during build)
 uv run mkdocs build --strict

--- a/tools/generate_ebnf_md.py
+++ b/tools/generate_ebnf_md.py
@@ -1,8 +1,0 @@
-from pathlib import Path
-
-p = Path("src/crv/core/core.ebnf")
-ebnf = p.read_text(encoding="utf-8")
-out = Path("docs/grammar/ebnf.md")
-out.parent.mkdir(parents=True, exist_ok=True)
-out.write_text("# CRV Core Grammar (EBNF)\n\n```ebnf\n" + ebnf + "\n```\n", encoding="utf-8")
-print(f"[ok] wrote {out}")


### PR DESCRIPTION
## Summary

Reorganize the documentation site into a professional 3-tab information architecture and generate a complete per-module API reference. Surface project and package READMEs, add a concrete Getting Started guide, and use a strict MkDocs build. Navigation is owned by literate-nav (SUMMARY.md generated at build-time).

## Motivation

- Existing docs mixed overview with API details and lacked a complete per-module API tree.
- Target IA is simple and predictable: Overview, Guide, API Reference.
- Provide real onboarding (Python 3.13+, uv install, clone, uv sync, demo run, strict docs build).
- Ensure every crv.\* module is discoverable with consistent mkdocstrings formatting.

## Context

Follow-up to recently merged PR #3: “io: canonical IO layer (append-only, manifests, dataset facade) + run bundle indexing” merged into main on 2025-09-22T15:14:11Z.

This PR focuses on documentation site IA, generation pipeline, and visibility of module guides and API. All commits in this docs effort will reference this PR draft.

## Changes

- mkdocs.yaml
  - Material theme with navigation.tabs and navigation.sections.
  - extra_javascript: js/diagrams-nav.js.
  - mkdocstrings (python) configured for clean grouping and signatures.
  - gen-files invokes tools/build_docs.py; literate-nav consumes generated SUMMARY.md.
- tools/build_docs.py
  - Grammar: write docs/grammar/ebnf.md from src/crv/core/core.ebnf and surface Markdown + HTML diagrams.
  - Index: surface top-level README.md as index.md (adds an explicit citation anchor).
  - Guides: surface package READMEs for Core/IO/Lab/Viz/Mind/World; add Guide/Getting Started with uv install, clone, uv sync, demo run, strict docs build.
  - API: generate package index pages (intentionally no ::: to avoid duplicate anchors) and per-module pages for core, io, lab, mind, viz, world.
  - Navigation: emit SUMMARY.md implementing the 3-tab IA via literate-nav.
- tools/generate_docs.sh
  - Build EBNF diagrams via Node (tools/ebnf), then run `uv run mkdocs build --strict`. Handled automatically by `tools/generate_docs.sh`, the preferred entry point for this instead of manually.
  - Updated docstrings to ensure passing docs. Note that some module docstrings will inevitably change in upcoming PRs for `world`, `lab`, `mind`, `viz`.

## mkdocstrings settings (effective)

- handlers.python.paths: [src]
- options:
  - docstring_style: google
  - show_source: true
  - show_root_heading: true
  - separate_signature: true
  - inherited_members: true
  - filters: ["!^_"]
  - show_if_no_docstring: true
  - members_order: source
  - group_by_category: true
  - show_signature: true
  - show_signature_annotations: true
  - annotations_path: full
  - show_submodules: false
  - show_object_full_path: false
  - show_root_full_path: false
  - line_length: 88

## Site structure (after)

- Overview
- Guide
  - Getting Started
  - Core
    - Contracts (README)
    - Grammar (EBNF)
    - Grammar diagrams (HTML)
  - IO (README)
  - Lab (README)
  - Viz (README)
  - Mind (README)
  - World (README)
- API Reference
  - crv.core (package index + module pages)
  - crv.io
  - crv.lab
  - crv.mind
  - crv.viz
  - crv.world

## Highlights

- 3-tab navigation controlled by literate-nav (generated SUMMARY.md).
- Getting Started includes:
  - Python 3.13+ prerequisite and uv install (curl/pipx), clone repo, uv sync.
  - Quick demo run and strict docs build command.
- Full API reference:
  - Per-package module pages under `api/` with `:::` directives.
  - Package index pages omit `:::` to avoid duplicate anchors.
- mkdocstrings formatting:
  - Grouped categories, readable signatures with annotations, show_source, inherited_members, private filtered, members_order=source, annotations_path=full.
- Strict build via `uv run mkdocs build --strict` (enforced in tools/generate_docs.sh).

## Getting started (local preview)

```bash
# Build the docs (strict)
bash tools/generate_docs.sh

# Open the site locally
open site/index.html
```

## Verification

- Nav shows exactly 3 tabs: Overview, Guide, API Reference.
- Guide contains Getting Started, Core (Contracts/EBNF/Diagrams), and module guides (IO/Lab/Viz/Mind/World).
- API Reference lists packages core, io, lab, mind, viz, world; all modules render with grouped categories and readable signatures; no duplicate anchors.
- Strict build passes with no autoref duplication or griffe errors.

## Breaking changes

- None. Docs-only; no runtime behavior changes.

## Reviewer checklist

- [ ] Overview remains high-level (no API dump).
- [ ] Guide includes Getting Started (Python 3.13+, uv install, clone + uv sync, demo run, strict build).
- [ ] Guide includes Core (Contracts/EBNF/Diagrams) plus IO/Lab/Viz/Mind/World READMEs.
- [ ] API Reference shows all `crv.*` packages with per-module pages; no duplicate anchors on package pages.
- [ ] mkdocstrings formatting reads cleanly (grouping, signatures, annotations).
- [ ] Strict build passes via `bash tools/generate_docs.sh`.

## Notes for reviewers

- This consolidates docs IA and API discoverability. Related planning docs:
  - plans/io/AUDIT_2025-09-22_crv_io_status.md
  - plans/io/io_module_starter_plan.md
  - plans/io/run_bundle_and_lab_integration_plan.md
  - plans/io/start_task.md

## Follow-ups

- OS-specific uv installation variants (brew/choco), and additional troubleshooting notes.
- Examples linking World + Mind + Lab flows with IO Run Bundle.

## Additional Docs Changes (DSPy-based llms.txt)

- Add tools/docs_llms.py (modular generator: PageRef, ExternalLink, LLMSConfig; DSPy-first with compatibility for DSPy 3.x via dspy.OpenAI/OpenRouter or dspy.LM("provider/model")); pretty URL seeds; safe fallback retained.
- Wire into tools/build_docs.py: mkdocs-gen-files writes llms.txt (no repo writes); imports kept at top.
- Update tools/generate_docs.sh: ; export PYTHONPATH="/Users/metis/Projects/cicl/code/crv_agents:" so mkdocs can import repo-root tools; suppress litellm DeprecationWarning; enforce DSPy (DOCS_DSPY_REQUIRED=true) when OPENAI_API_KEY is set so CI fails loudly instead of silently falling back.
- No changes to mkdocs.yaml; generation remains DRY (gen-files + literate-nav).

### Notes

- If DSPy is unavailable, fallback is used only when DOCS_DSPY_REQUIRED is not set.
- In CI, OPENAI_API_KEY enables DOCS_DSPY_REQUIRED automatically.
